### PR TITLE
Add `--filter` option to `recap refresh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ You can also configure your catalog and crawlers in `settings.toml`. Here's an e
 host = "0.0.0.0"
 
 [catalog]
-url = file:///tmp/recap.duckdb
+url = "file:///tmp/recap.duckdb"
 
 [[crawlers]]
 url = "bigquery://some-project-12345"

--- a/recap/crawlers/db/__init__.py
+++ b/recap/crawlers/db/__init__.py
@@ -18,4 +18,12 @@ def open(
     browser = DatabaseBrowser(engine)
     # TODO make analyzers configurable
     analyzers = [analyzer(engine) for analyzer in DEFAULT_ANALYZERS]
-    yield DatabaseCrawler(infra, instance, catalog, browser, analyzers)
+    filters = config.get('filters', [])
+    yield DatabaseCrawler(
+        infra,
+        instance,
+        catalog,
+        browser,
+        analyzers,
+        filters,
+    )


### PR DESCRIPTION
Users can now control which schemas and tables a crawler scans. This can done via the CLI or `settings.toml`. The CLI parameter `--filter` controls the schemas and tables to be scanned:

    recap run refresh --filter='events.page_*' --filter='clicks.click_table'

In `settings.toml` configuration looks like so:

```
[[crawlers]]
url = "postgresql://chrisriccomini@localhost/some_db"
filters = [
    "events.page_*",
    "clicks.click_table"
]
```

The filter format follows Unix shell-style wildcards as defined in Python [1]. The `fnmatch` pattern is matched against `<schema>.<format>` patterns as the crawler crawls.

[1] https://docs.python.org/3/library/fnmatch.html