### PR TITLE
Add `--analyzer` option to `recap refresh`

### DIFF
--- a/recap/cli.py
+++ b/recap/cli.py
@@ -1,6 +1,7 @@
 import typer
 from . import catalog
 from .config import settings
+from .crawlers.db.analyzers import DEFAULT_ANALYZERS
 from rich import print_json
 from typing import List, Optional
 
@@ -28,6 +29,12 @@ def refresh(
             "Filter to crawl only certain '<schema>.<name>'. "
             "Format is Unix shell-style wildcards."
     ),
+    analyzer: Optional[List[str]] = typer.Option(
+        DEFAULT_ANALYZERS,
+        help=\
+            "Analyzer to use when crawling. "
+            "Format is 'some.module.Class'."
+    ),
 ):
     from . import crawlers
 
@@ -43,6 +50,10 @@ def refresh(
         for crawler_config in crawler_config_list:
             if not url or url == crawler_config['url']:
                 crawler_config['filters'] = filter
+    if analyzer:
+        for crawler_config in crawler_config_list:
+            if not url or url == crawler_config['url']:
+                crawler_config['analyzers'] = analyzer
 
     with catalog.open(**settings('catalog', {})) as ca:
         for crawler_config in crawler_config_list:

--- a/recap/crawlers/__init__.py
+++ b/recap/crawlers/__init__.py
@@ -1,5 +1,4 @@
 import importlib
-# TODO When I create an AbstractCrawler, use it here
 from contextlib import contextmanager
 from recap.crawlers.abstract import AbstractCrawler
 from recap.catalog.abstract import AbstractCatalog

--- a/recap/crawlers/db/analyzers.py
+++ b/recap/crawlers/db/analyzers.py
@@ -255,13 +255,15 @@ class TableDataAnalyzer(AbstractTableAnalyzer):
             return {'data_profile': results}
 
 
-DEFAULT_ANALYZERS = [
+
+# Do not include TableDataAnalyzer because it's expensive to run.
+DEFAULT_ANALYZERS = list(map(lambda t: t.__module__ + '.' + t.__qualname__, [
     TableAccessAnalyzer,
     TableColumnAnalyzer,
     TableCommentAnalyzer,
-    TableDataAnalyzer,
     TableForeignKeyAnalyzer,
     TableIndexAnalyzer,
     TablePrimaryKeyAnalyzer,
     ViewDefinitionAnalyzer,
-]
+])
+)


### PR DESCRIPTION
I'm hooking up the other half of the analyzer implementation to `db.Crawler`. Prior to this change, the `DEFAULT_ANALYZER` param was hard coded for `db.Crawler`, so users couldn't set the analyzers they want to use. Now they can. use the `--analyzer` command:

```
pdm run recap refresh postgresql://chrisriccomini@localhost/some_db \
    --analyzer=recap.crawlers.db.analyzers.TableColumnAnalyzer \
    --analyzer=recap.crawlers.db.analyzers.TableAccessAnalyze
```

Users may also use the `settings.toml` file if they prefer:

```
[[crawlers]]
url = "postgresql://chrisriccomini@localhost/some_db"
analyzers = [
    "recap.crawlers.db.analyzers.TableColumnAnalyzer",
    "recap.crawlers.db.analyzers.TableAccessAnalyze"
]
```

I also took the opportunity to remove `TableDataProfilerAnalyzer` from the default analyzer list since it's slow and expensive to run on large tables. Users must now set it explicitly.

My implementation has two notable problems:

1. Users aren't able to supply configs for analyzers right now. All current.. analyzers don't need any config, but if they did, it'd be a problem.
2. All analyzers are treated as AbstractTableAnalyzers. This won't work when.. I add streaming and filesystem infrastructure support.