### PR TITLE
Add CLI plugins

### DIFF
--- a/recap/cli.py
+++ b/recap/cli.py
@@ -2,11 +2,12 @@ import typer
 from . import catalog
 from .config import settings
 from .crawlers.db.analyzers import DEFAULT_ANALYZERS
+from .plugins import load_cli_plugins
 from rich import print_json
 from typing import List, Optional
 
 
-app = typer.Typer()
+app = load_cli_plugins(typer.Typer())
 
 
 @app.command()

--- a/recap/plugins.py
+++ b/recap/plugins.py
@@ -1,0 +1,30 @@
+import typer
+import sys
+
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
+
+CLI_PLUGIN_GROUP = 'recap.plugins.cli'
+
+
+def load_cli_plugins(app) -> typer.Typer:
+    cli_plugins = entry_points(group=CLI_PLUGIN_GROUP)
+
+    for cli_plugin in cli_plugins:
+        cli_plugin_name = cli_plugin.name
+        cli_plugin_typer = cli_plugin.load()
+        # If the plugin has a single command, then put it directly into the
+        # current Typer app. If the plugin has multiple commands, then treat it
+        # as a command group, and add it as such.
+        # TODO Shouldn't need to do this, but Typer has a bug.
+        # https://github.com/tiangolo/typer/issues/119
+        if len(cli_plugin_typer.registered_commands) == 1:
+            app.command(cli_plugin_name)(cli_plugin_typer.registered_commands[0].callback)
+        else:
+            app.add_typer(cli_plugin_typer, name=cli_plugin_name)
+
+    return app


### PR DESCRIPTION
Developers can now write plugins for Recap's CLI. Plugins are simply [Typer](https://typer.tiangolo.com/) apps, just like Recap's CLI.

To write a plugin, developers must define an entry-point in their project. Here's how it'd look in `pyproject.toml`:

```
[project.entry-points."recap.plugins.cli"]
hello-world = "recap.test:app"
```

`hello-world` defines the name of the command to be loaded into Recap. `recap.test:app` defines the module location and variabile name of the `typer.Typer` app. In this example, the `app` might be defined like so:

```
import typer
from rich import print

app = typer.Typer()

@app.command()
def hello_world_extension(name: str):
    """
    A hello world test
    """
    print(f'Hello, {name}!')

@app.command()
def goodbye_world_extension():
    print('Goodbye, world!')
```

This example plugin has two subcommands: `hello_world_extension` and `goodbye_world_extension`.

Once the package is built, it can be installed using a standard `pip install <plugin-package-name>`. After the installation, Recap will expose the plugin commands automatically:

```
recap hello-world --help

 Usage: recap hello-world [OPTIONS] COMMAND [ARGS]...

╭─ Options ────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                  │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ goodbye-world-extension                                                      │
│ hello-world-extension                       A hello world test               │
╰──────────────────────────────────────────────────────────────────────────────╯
```

If a plugin has only a single `@app.command`, then Recap will use it as a top-level command rather than using a command group. For example, if `goodbye_world_extension` were removed from the plugin above, then `recap hello-world Chris` would automatically invoke `hello_world_extension(name='Chris')`.

closes #51