### PR TITLE
Add a nice spinner when crawling in the CLI

### DIFF
--- a/recap/crawlers/__init__.py
+++ b/recap/crawlers/__init__.py
@@ -11,6 +11,7 @@ def guess_infra(url: str) -> str | None:
     # Given `posgrestql+psycopg2://foo:bar@baz/some_db`, return `postgresql`.
     return parsed_url.scheme.split('+')[0]
 
+
 def guess_instance(url: str) -> str | None:
     parsed_url = urlparse(url)
     # Given `posgrestql+psycopg2://foo:bar@baz/some_db`, return `baz`.

--- a/recap/plugins.py
+++ b/recap/plugins.py
@@ -11,7 +11,7 @@ else:
 CLI_PLUGIN_GROUP = 'recap.plugins.cli'
 
 
-def load_cli_plugins(app) -> typer.Typer:
+def load_cli_plugins(app: typer.Typer) -> typer.Typer:
     cli_plugins = entry_points(group=CLI_PLUGIN_GROUP)
 
     for cli_plugin in cli_plugins:


### PR DESCRIPTION
Crawling sometimes takes a while. I've added a little `rich` SpinnerColumn and Progress task that spins while crawling is happening. When complete, a checkmark is displayed. I've also parsed out just the infra and instance name to avoid printing potentially sensitive information to the CLI (like usernames, passwords, and query params).

```
recap refresh postgresql://chrisriccomini@localhost/some_db
✓ Crawling postgresql://localhost ...
```