### PR TITLE
Add logging to Recap

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -234,6 +234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+requires_python = ">=3.7"
+summary = "A lil' TOML parser"
+
+[[package]]
 name = "typer"
 version = "0.7.0"
 requires_python = ">=3.6"
@@ -312,7 +318,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:8e20030159cf5f8bd6b7af94f314e5bbb2f1f18091b5fc3a2bb7191f9b2bb5cf"
+content_hash = "sha256:74f43768c1d66644095b5493fb2e7e2ad9b10b299bec7801b7f06fc63eaa74cf"
 
 [metadata.files]
 "anyio 3.6.2" = [
@@ -709,6 +715,10 @@ content_hash = "sha256:8e20030159cf5f8bd6b7af94f314e5bbb2f1f18091b5fc3a2bb7191f9
 "starlette 0.22.0" = [
     {url = "https://files.pythonhosted.org/packages/1d/4e/30eda84159d5b3ad7fe663c40c49b16dd17436abe838f10a56c34bee44e8/starlette-0.22.0-py3-none-any.whl", hash = "sha256:b5eda991ad5f0ee5d8ce4c4540202a573bb6691ecd0c712262d0bc85cf8f2c50"},
     {url = "https://files.pythonhosted.org/packages/f7/ff/64bd3362f80e81402f21e0f1ba55f8801cd899ad3f2a1bcc4a94d284c786/starlette-0.22.0.tar.gz", hash = "sha256:b092cbc365bea34dd6840b42861bdabb2f507f8671e642e8272d2442e08ea4ff"},
+]
+"tomli 2.0.1" = [
+    {url = "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {url = "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 "typer 0.7.0" = [
     {url = "https://files.pythonhosted.org/packages/0d/44/56c3f48d2bb83d76f5c970aef8e2c3ebd6a832f09e3621c5395371fe6999/typer-0.7.0-py3-none-any.whl", hash = "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "rich>=12.6.0",
     "setuptools>=65.6.3",
     "duckdb>=0.6.1",
+    "tomli>=2.0.1",
 ]
 # <3.11 to make Recap work with sqlalchemy-bigquery
 requires-python = ">=3.9, <3.11"

--- a/recap/cli.py
+++ b/recap/cli.py
@@ -2,12 +2,14 @@ import typer
 from . import catalog
 from .config import settings
 from .crawlers.db.analyzers import DEFAULT_ANALYZERS
+from .logging import setup_logging
 from .plugins import load_cli_plugins
 from rich import print_json
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from typing import List, Optional
 
 
+LOGGING_CONFIG = setup_logging()
 app = load_cli_plugins(typer.Typer())
 
 
@@ -18,6 +20,7 @@ def api():
 
     uvicorn.run(
         app,
+        log_config=LOGGING_CONFIG,
         **settings('api', {}),
     )
 

--- a/recap/crawlers/db/browser.py
+++ b/recap/crawlers/db/browser.py
@@ -1,7 +1,11 @@
+import logging
 import sqlalchemy as sa
 from recap.crawlers.abstract import AbstractBrowser
 from pathlib import PurePosixPath
 from typing import List, Callable
+
+
+log = logging.getLogger(__name__)
 
 
 class DatabaseBrowser(AbstractBrowser):
@@ -43,11 +47,18 @@ class DatabaseBrowser(AbstractBrowser):
         results = []
         try:
             for table_or_view in get_method(schema):
+                # Stripe schema name from the table/view name. Some dialects
+                # include the schema name as part of the table/view. Let's keep
+                # things consistent.
                 if table_or_view.startswith(f"{schema}."):
                     table_or_view = table_or_view[len(schema) + 1:]
                 results.append(table_or_view)
-        except:
+        except Exception as e:
             # Just optimistically try, and ignore if we can't get info.
             # Easier than trying to figure out if permission exists.
-            pass
+            log.debug(
+                'Unable to fetch tables or views for schema=%s',
+                schema,
+                exc_info=e
+            )
         return results

--- a/recap/logging.py
+++ b/recap/logging.py
@@ -1,0 +1,53 @@
+import logging.config
+import tomli
+from .config import settings
+from pathlib import Path
+from typing import Any
+
+
+LOGGING_CONFIG_PATH = 'logging.config.path'
+DEFAULT_LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'standard': {
+            'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+        },
+    },
+    'handlers': {
+        'default': {
+            'formatter': 'standard',
+            'class': 'rich.logging.RichHandler',
+            'show_time': False,
+            'show_level': False,
+            'show_path': False,
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['default'],
+            'level': 'WARNING',
+            'propagate': False
+        },
+        'recap': {
+            'handlers': ['default'],
+            'level': 'INFO',
+            'propagate': False
+        },
+        'uvicorn': {
+            'handlers': ['default'],
+            'level': 'INFO',
+            'propagate': False
+        },
+    }
+}
+
+def setup_logging() -> dict[str, Any]:
+    logging_config = DEFAULT_LOGGING_CONFIG
+    logging_config_file_loc = settings(LOGGING_CONFIG_PATH)
+    if logging_config_file_loc:
+        logging_config_file_path = Path(logging_config_file_loc)
+        logging_config_string = logging_config_file_path.read_text()
+        logging_config = tomli.loads(logging_config_string)
+    logging.config.dictConfig(logging_config)
+    return logging_config


### PR DESCRIPTION
Recap now has logging in the DB crawler and analyzer modules. I created a basic `logging.py` file with `setup_logging`, as well. `setup_logging` tries to load a Python dictionary from a .toml file using `tomli` [1]. The logging config should be in dictConfig format [2]. `setup_logging` looks in the `logging.config.path` config variable (or `RECAP_LOGGING__CONFIG__PATH` env var, I think) for the path to the logging config .toml file.

A default logging config is used when no `logging.config.path` is set. The default logging config is found in `logging.py`. It uses [RichHandler](https://rich.readthedocs.io/en/latest/logging.html), and sets a nicer timestamp format. It also configures the default log level to `INFO`. As a bonus, RichHandler also plays nicely with Rich's spinner console animations (it doesn't mangle or intermingle itself).

Recap's logging configs are also passed from `setup_logging` into the `uvicorn` server, so Recap's logging system is used with `uvicorn` when running `recap api`.

[1] I used `tomli` for TOML parsing so we're forwards compatible when I upgrade to 3.11. I can then switch to the in-built `tomllib` library and drop the `tomli` dependency.
[2] https://docs.python.org/3/library/logging.config.html#logging-config-dictschema