### PR TITLE
Add `recap plugins` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,15 +48,15 @@ jq = [
 all = ["recap[jq]"]
 
 [project.entry-points."recap.analyzers"]
-access = "recap.plugins.analyzers.table:TableAccessAnalyzer"
-column = "recap.plugins.analyzers.table:TableColumnAnalyzer"
-comment = "recap.plugins.analyzers.table:TableCommentAnalyzer"
-foreign_key = "recap.plugins.analyzers.table:TableForeignKeyAnalyzer"
-index = "recap.plugins.analyzers.table:TableIndexAnalyzer"
-location = "recap.plugins.analyzers.table:TableLocationAnalyzer"
-primary_key = "recap.plugins.analyzers.table:TablePrimaryKeyAnalyzer"
-profile = "recap.plugins.analyzers.table:TableProfileAnalyzer"
-view_definitions = "recap.plugins.analyzers.table:TableViewDefinitionAnalyzer"
+"db.access" = "recap.plugins.analyzers.table:TableAccessAnalyzer"
+"db.column" = "recap.plugins.analyzers.table:TableColumnAnalyzer"
+"db.comment" = "recap.plugins.analyzers.table:TableCommentAnalyzer"
+"db.foreign_key" = "recap.plugins.analyzers.table:TableForeignKeyAnalyzer"
+"db.index" = "recap.plugins.analyzers.table:TableIndexAnalyzer"
+"db.location" = "recap.plugins.analyzers.table:TableLocationAnalyzer"
+"db.primary_key" = "recap.plugins.analyzers.table:TablePrimaryKeyAnalyzer"
+"db.profile" = "recap.plugins.analyzers.table:TableProfileAnalyzer"
+"db.view_definitions" = "recap.plugins.analyzers.table:TableViewDefinitionAnalyzer"
 
 [project.entry-points."recap.browsers"]
 db = "recap.plugins.browsers.db:DatabaseBrowser"
@@ -69,6 +69,7 @@ recap = "recap.plugins.catalogs.recap:RecapCatalog"
 [project.entry-points."recap.commands"]
 catalog = "recap.plugins.commands.catalog:app"
 crawl = "recap.plugins.commands.crawl:app"
+plugins = "recap.plugins.commands.plugins:app"
 serve = "recap.plugins.commands.serve:app"
 
 [build-system]

--- a/recap/cli.py
+++ b/recap/cli.py
@@ -1,10 +1,10 @@
 import typer
 from .logging import setup_logging
-from .plugins import load_command_plugins
+from .plugins import init_command_plugins
 
 
 LOGGING_CONFIG = setup_logging()
-app = load_command_plugins(typer.Typer())
+app = init_command_plugins(typer.Typer())
 
 
 if __name__ == "__main__":

--- a/recap/plugins/commands/plugins.py
+++ b/recap/plugins/commands/plugins.py
@@ -1,0 +1,29 @@
+import typer
+from itertools import chain
+from recap import plugins
+from recap.config import settings
+from rich import print_json
+from pathlib import PurePosixPath
+
+
+app = typer.Typer()
+
+
+@app.command()
+def analyzers():
+    print_json(data=list(plugins.load_analyzer_plugins().keys()))
+
+
+@app.command()
+def browsers():
+    print_json(data=list(plugins.load_browser_plugins().keys()))
+
+
+@app.command()
+def catalogs():
+    print_json(data=list(plugins.load_catalog_plugins().keys()))
+
+
+@app.command()
+def commands():
+    print_json(data=list(plugins.load_command_plugins().keys()))


### PR DESCRIPTION
Add a simple `recap plugins` command that lists the current plugins. The command has four subcommands: `analyzers`, `browsers`, `catalogs`, and `commands`. Specifying one will list the plugins for that type.

```
recap plugins analyzers
[
  "db.access",
  "db.column",
  "db.comment",
  "db.foreign_key",
  "db.index",
  "db.location",
  "db.primary_key",
  "db.profile",
  "db.view_definitions"
]
```