### PR TITLE
Add expanded documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,220 +4,39 @@
 </h1>
 
 <p align="center">
-<i>Recap crawls and serves metadata</i>
+<i>A dead simple data catalog for engineers</i>
 </p>
 
-There are a ton of data catalogs out there, but most are complex, bloated, and built for a wide audience. Recap is the opposite of that; it's tiny and built specifically for engineers.
+## Features
 
-You can use Recap to build data tools for:
+* Supports major cloud data warehouses and Postgres
+* No external system dependencies to get started
+* Designed for the CLI
+* Runs as a Python library or REST API
+* Customizable with plugins
 
-* Observability
-* Monitoring
-* Debugging
-* Security
-* Compliance
-* Governance
-* Cost
+## Installation
 
-## Principles
+    pip install recap-core
 
-Recap was designed to be small and flexible.
+## Commands
 
-* **Lightweight**: Recap starts with a single command and doesn't require other infrastructure (not even Docker).
-* **CLI-first**: Recap doesn't even have a GUI!
-* **RESTful**: Recap comes with a REST API to ease integration with outside tools.
-* **Automated**: Recap is not meant for manual taxonomy curation.
-* **Modular**: Recap's storage and crawling layers are fully pluggable.
-* **Programmable**: Recap is a Python library, so you can invoke it directly from your code.
+* `recap catalog list` - List a data catalog directory.
+* `recap catalog read` - Read metadata from the data catalog.
+* `recap catalog search` - Search the data catalog for metadata.
+* `recap crawl` - Crawl infrastructure and save metadata in the data catalog.
+* `recap plugins analyzers` - List all analyzer plugins.
+* `recap plugins browsers` - List all browser plugins.
+* `recap plugins catalogs` - List all catalog plugins.
+* `recap plugins commands` - List all command plugins.
+* `recap serve` - Start Recap's REST API.
 
-## Integrations
+## Getting Started
 
-Recap uses [SQLAlchemy](https://www.sqlalchemy.org/) to access databases, so any SQLAlchemy dialect should work. Recap has been tested with:
-
-* Snowflake
-* Bigquery
-* PostgreSQL
-
-Stream and filesystem crawling is in the works.
-
-## Usage
-
-### Quickstart
-
-Start by installing Recap. Python 3.9 or above is required.
-
-```
-pip install recap-core
-```
-
-Now let's crawl a database:
-
-    recap refresh postgresql://username@localhost/some_db
-
-You can use any SQLAlchemy connect string. 
-
-    recap refresh bigquery://some-project-12345
-    recap refresh snowflake://some_user:some_pass@some_account_id
-
-For Snowflake and BigQuery, you'll have to `pip install snowflake-sqlalchemy` or `pip install sqlalchemy-bigquery`, respectively.
-
-Crawled metadata is stored in a directory structure. See what's available using:
-
-    recap list /
-
-Recap will respond with a JSON list:
-
-```
-[
-  "databases"
-]
-```
-
-Append children to the list path to browse around:
-
-    recap list /databases
-
-After you poke around, try and read some metadata. Every node in the path can have metadata, but only table and view children contain metadata. You can look at metadata using the `recap read` command:
-
-```
-recap read /databases/postgresql/instances/localhost/schemas/some_db/tables/some_table
-```
-
-Recap will print all of `some_table`'s metadata to the CLI in JSON format:
-
-```
-{
-  "access": {
-    "username": {
-      "privileges": [
-        "INSERT",
-        "SELECT",
-        "UPDATE",
-        "DELETE",
-        "TRUNCATE",
-        "REFERENCES",
-        "TRIGGER"
-      ],
-      "read": true,
-      "write": true
-    }
-  },
-  "columns": {
-    "email": {
-      "autoincrement": false,
-      "default": null,
-      "generic_type": "VARCHAR",
-      "nullable": false,
-      "type": "VARCHAR"
-    },
-    "id": {
-      "autoincrement": true,
-      "default": "nextval('\"some_db\".some_table_id_seq'::regclass)",
-      "generic_type": "BIGINT",
-      "nullable": false,
-      "type": "BIGINT"
-    }
-  },
-  "data_profile": {
-    "email": {
-      "count": 10,
-      "distinct": 10,
-      "empty_strings": 0,
-      "max_length": 32,
-      "min_length": 13,
-      "nulls": 0
-    },
-    "id": {
-      "average": 5.5,
-      "count": 10,
-      "max": 10,
-      "min": 1,
-      "negatives": 0,
-      "nulls": 0,
-      "sum": 55.0,
-      "zeros": 0
-    }
-  },
-  "indexes": {
-    "index_some_table_on_email": {
-      "columns": [
-        "email"
-      ],
-      "unique": false
-    }
-  },
-  "location": {
-    "database": "postgresql",
-    "instance": "localhost",
-    "schema": "some_db",
-    "table": "some_table"
-  },
-  "primary_key": {
-    "constrained_columns": [
-      "id"
-    ],
-    "name": "some_table_pkey"
-  }
-}
-```
-
-You can search for metadata, too. Recap stores its metadata in [DuckDB](https://duckdb.org/) by default, so you can use DuckDB's [JSON path syntax](https://duckdb.org/docs/extensions/json) to search the catalog:
-
-    recap search "metadata->'$.location'->>'$.table' = 'some_table'"
-
-The database file defaults to `~/.recap/catalog/recap.duckdb`, if you wish to open a DuckDB client directly.
-
-### API
-
-#### Server
-
-Recap comes with an API out of the box. You can start it with:
-
-    recap api
-
-A `uvicorn` server will bind to http://localhost:8000 by default. You can look at the API endpoints using http://localhost:8000/docs.
-
-You can pass custom `uvicorn` configuration by creating `~/.recap/settings.toml` and setting parameters under the `api` space like:
-
-```
-api.host = "0.0.0.0"
-```
-
-#### Client
-
-You can use Recap's CLI to query a remote Recap API server if you wish. Set `catalog.url` in `settings.toml` to point to your Recap API location.
-
-```
-catalog.url = "http://localhost:8000"
-```
-
-### Configuration
-
-Recap uses [Dynaconf](https://www.dynaconf.com/) to manage configuration. By default, Recap can see anything you put into `~/recap/settings.toml`.
-
-You can customize your `settings.toml` location using the `SETTINGS_FILE_FOR_DYNACONF` environment variable:
-
-    SETTINGS_FILE_FOR_DYNACONF=/tmp/api.toml recap list
-
-You can also configure your catalog and crawlers in `settings.toml`. Here's an example:
-
-```
-[api]
-host = "0.0.0.0"
-
-[catalog]
-url = "file:///tmp/recap.duckdb"
-
-[[crawlers]]
-url = "bigquery://some-project-12345"
-
-[[crawlers]]
-url = "postgresql://username@localhost/some_db"
-
-[[crawlers]]
-url = "snowflake://some_user:some_pass@some_account_id"
-```
+See the [Quickstart](https://docs.recap.cloud/latest/quickstart/) page to get started.
 
 ## Warning
+
+> ⚠️ This package is still under development and may not be stable. The API may break at any time.
 
 Recap is still a little baby application. It's going to wake up crying in the middle of the night. It's going to vomit on the floor once in a while. But if you give it some love and care, it'll be worth it. As time goes on, it'll grow up and be more mature. Bear with it.

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -1,0 +1,169 @@
+Recap analyzers generate metadata; they're given a path and return a dictionary of metadata.
+
+!!! note
+
+    `recap crawl` will run all available analyzers, if possible. You can exclude analyzers using `--exclude`. See the [commands](commands.md) documentation for more information.
+
+## Database Analyzers
+
+Recap ships with the following analyzer plugins:
+
+* `db.access`
+* `db.column`
+* `db.comment`
+* `db.foreign_key`
+* `db.index`
+* `db.location`
+* `db.primary_key`
+* `db.profile`
+* `db.view_definitions`
+
+### Access
+
+Returns user access information for a table or view.
+
+```json
+"access": {
+  "<username>": {
+    "privileges": [
+      "INSERT",
+      "SELECT",
+      "UPDATE",
+      "DELETE",
+      "TRUNCATE",
+      "REFERENCES",
+      "TRIGGER"
+    ],
+    "read": true,
+    "write": true
+  }
+}
+```
+
+### Column
+
+Returns column schemas.
+
+```json
+"columns": {
+  "email": {
+    "autoincrement": false,
+    "default": null,
+    "generic_type": "VARCHAR",
+    "nullable": false,
+    "type": "VARCHAR"
+  },
+  "id": {
+    "autoincrement": true,
+    "default": "nextval('\"some_db\".some_table_id_seq'::regclass)",
+    "generic_type": "BIGINT",
+    "nullable": false,
+    "type": "BIGINT"
+  }
+}
+```
+
+### Comment
+
+Returns a table's coment, if any.
+
+```json
+"comment": "The roles that can be applied to the current user."
+```
+
+### Foreign Key
+
+Returns foreign key information.
+
+```json
+"foreign_keys": [
+  {
+    "constrained_columns": [
+      "some_id"
+    ],
+    "name": "fk_some_id",
+    "options": {},
+    "referred_columns": [
+      "id"
+    ],
+    "referred_schema": "some_schema",
+    "referred_table": "some_table"
+  }
+]
+```
+
+### Index
+
+Returns index information.
+
+```json
+"indexes": {
+  "index_some_table_on_email": {
+    "columns": [
+      "email"
+    ],
+    "unique": false
+  }
+}
+```
+
+### Location
+
+Returns the type, instance, schema, and table/ view location.
+
+```json
+"location": {
+  "database": "postgresql",
+  "instance": "localhost",
+  "schema": "some_db",
+  "table": "some_table"
+}
+```
+
+### Primary Key
+
+Returns primary key information
+
+```json
+"primary_key": {
+  "constrained_columns": [
+    "id"
+  ],
+  "name": "some_table_pkey"
+}
+```
+
+### Profile
+
+Returns basic table statistics (max, min, nulls, count, and so on).
+
+```json
+"profile": {
+  "email": {
+    "count": 10,
+    "distinct": 10,
+    "empty_strings": 0,
+    "max_length": 32,
+    "min_length": 13,
+    "nulls": 0
+  },
+  "id": {
+    "average": 5.5,
+    "count": 10,
+    "max": 10,
+    "min": 1,
+    "negatives": 0,
+    "nulls": 0,
+    "sum": 55.0,
+    "zeros": 0
+  }
+}
+```
+
+### View Definitions
+
+Returns a view's query, if any.
+
+```json
+"view_definition": "SELECT * FROM table;"
+```

--- a/docs/browsers.md
+++ b/docs/browsers.md
@@ -1,0 +1,33 @@
+Different data infrastructure have different types of objects:
+
+* schemas
+* tables
+* columns
+* files
+* paths
+* topics
+* partitions
+
+Recap uses a _browser_ abstraction to deal with different data infrastructure in a standard way.
+
+Browsers map infrastructure objects into a standard directory format. A different browser is used for each type of infrastructure. Out of the box, Recap ships with a [DatabaseBrowser](https://github.com/recap-cloud/recap/blob/main/recap/plugins/browsers/db.py), which maps database objects into a directory structure:
+
+```
+/
+/databases
+/databases/<some_db>
+/databases/<some_db>/instances
+/databases/<some_db>/instances/<some_instance>
+/databases/<some_db>/instances/<some_instance>/schemas
+/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>
+/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>/tables
+/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>/tables/<some_view>
+/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>/views
+/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>/views/<some_view>
+```
+
+!!! note
+
+    Browsers do not actually analyze a system's data for metdata, they simply show what's available.
+
+This directory path is what you use when you run `recap catalog list` and `recap catalog read`. The directory structure is also used when executing `recap crawl` with a `--filter` option.

--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -1,0 +1,44 @@
+Recap catalogs store metadata and expose read and search APIs. Recap ships with the [DuckDB](https://duckdb.org/), Filesystem, and Recap catalog implementations. The DuckDB catalog is enabled by default.
+
+## DuckDB Catalog
+
+The DuckDB catalog stores data in a local DuckDB file. By default, the file is located in `~/.recap/catalog/recap.duckdb`. Search is implemented using DuckDB's [JSON path](https://duckdb.org/docs/extensions/json) syntax. See [Commands](commands.md) for an example.
+
+You can configure the DuckDB catalog in your `settings.toml` like so:
+
+```toml
+[catalog]
+type = "duckdb"
+url = "file:///some/path/to/duck.db"
+duckdb.read_only = true
+```
+
+Anything under the `catalog.duckdb` namespace will be forwarded to the DuckDB Python client.
+
+## Filesystem Catalog
+
+The filesystem catalog uses [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) to persist metadata in a filesystem (or object store like S3).
+
+Search is implemented using [pyjq](https://pypi.org/project/pyjq/). The filesystem catalog recurses over every metadata file in the catalog and runs a [jq](https://stedolan.github.io/jq/) query on each JSON file.
+
+Configure the filesystem catalog with `type = "fs"`.
+
+```toml
+[catalog]
+type = "fs"
+url = "file:///some/catalog/directory"
+```
+
+Anything under the `catalog.fs` namespace will be forwarded to the `fsspec.filesystem` Python call.
+
+## Recap Catalog
+
+The Recap catalog makes HTTP requests to a [Recap server](server.md).
+
+```toml
+[catalog]
+type = "recap"
+url = "http://localhost:8000"
+```
+
+The Recap catalog enables different systems to share the same metadata when they all talk to the same Recap server.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,75 @@
+Recap ships with four standard command plugins:
+
+* `recap catalog`
+* `recap crawl`
+* `recap plugins`
+* `recap serve`
+
+!!! note
+
+    You can see all available commands by running `recap --help` or `recap plugins commands`.
+
+## Catalog
+
+Recaps `recap catalog` command reads metadata Recap's data catalog. List the catalog's directory structure with `recap list`, read metadata from a directory with `recap read`, and search with `recap search`.
+
+### Search
+
+Recap's search syntax depends on the [Catalog](catalogs.md) plugin that's used. As mentioned in the [Quickstart](quickstart.md), Recap stores its metadata in [DuckDB](https://duckdb.org) by default. You can use DuckDB's [JSON path syntax](https://duckdb.org/docs/extensions/json) to search the catalog:
+
+    recap catalog search "metadata->'$.location'->>'$.table' = 'some_table'"
+
+The database file defaults to `~/.recap/catalog/recap.duckdb`, if you wish to open a DuckDB client directly.
+
+## Crawl
+
+Use `recap crawl` to crawl infrastructure and store its metadata in Recap's catalog. The `crawl` command takes an optional `URL` parameter. If specified, the URL will be crawled. If not specified, all `crawlers` defined in your `settings.toml` file will be crawled (see [Configuration](configuration.md) for more information).
+
+### Excludes
+
+You might not want to use all analyzers when crawling infrastrucutre. Some analyzers (particularly the `profile` analyzer) are costly and slow to run. To exclude an analyzer, use `--exclude` with `recap crawl`. For example:
+
+    recap crawl postgresql://username@localhost/some_db --exclude='db.profile'
+
+### Filters
+
+Recap crawls all paths by default, which can be slow. You might wish to only crawl some subset of data. You can use `--filter` to control what data the crawler looks at. Recap uses Unix filename pattern matching as defined in Python's [fnmatch](https://docs.python.org/3/library/fnmatch.html) module.
+
+To crawl only a specific table, you would use this syntax:
+
+    recap crawl postgresql://username@localhost/some_db --filter='/**/tables/some_table'
+
+## Plugins
+
+The `recap plugins` command lists the Recap plugins that you have installed in your environment.
+
+To list the available analyzers, run this command:
+
+```
+recap plugins analyzers
+[
+  "db.access",
+  "db.column",
+  "db.comment",
+  "db.foreign_key",
+  "db.index",
+  "db.location",
+  "db.primary_key",
+  "db.profile",
+  "db.view_definitions"
+]
+```
+
+See `recap plugins --help` for more.
+
+## Serve
+
+You might wish to centralize your Recap data catalog in one place, and have all users read from the same location. Recap ships with an HTTP/JSON server for this use case. Start a Recap server on a single host using `recap serve`. Clients can then configure their [Recap catalog](catalogs.md#recap-catalog) in `settings.toml` to point to the server location:
+
+```toml
+[catalog]
+type = "recap"
+url = "http://192.168.0.1:8000"
+```
+
+See the [server](server.md) documentation for more information.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,31 @@
+Though Recap's CLI can run without any configuration, you might want to configure Recap using a config file. Recap uses [Dynaconf](https://www.dynaconf.com/) for its configuration system.
+
+## Config Locations
+
+Configuraton is stored in `~/.recap/settings.toml` by default. You can override the default location by setting the `SETTINGS_FILE_FOR_DYNACONF` environment variable. See Dynaconf's [documentation](https://www.dynaconf.com/configuration/#envvar) for more information.
+
+## Schema
+
+Recap's `settings.toml` has two main sections: `catalog` and `crawlers`.
+
+* The `catalog` section configures the storage layer; it uses DuckDB by default. Run `recap plugins catalogs` to see other options.
+* The `crawlers` section defines infrastructure to crawl. Only the `url` field is required. You may optionally specify analyzer `excludes` and path `filters` as well.
+
+```toml
+[catalog]
+type = "recap"
+url = "http://localhost:8000"
+
+[[crawlers]]
+url = "postgresql://username@localhost/some_db"
+excludes = [
+	"db.profile"
+]
+filters = [
+	"/**/tables/some_table"
+]
+```
+
+## Secrets
+
+Do not store database credentials in your `settings.toml`; use Dynaconf's secret management instead. See Dynaconf's [documentation](https://www.dynaconf.com/secrets/) for more information.

--- a/docs/crawler.md
+++ b/docs/crawler.md
@@ -1,0 +1,28 @@
+Recap's crawler does three things:
+
+1. Browses the configured infrastructure
+2. Analyzes the infrastructure's data to generate metadata
+3. Stores the metadata in Recap's data catalog
+
+## Behavior
+
+Recap's crawler is very simple right now. The crawler recursively browses and analyzes all children starting from an infrastructre's root location.
+
+!!! note
+    The meaning of an infrastructure's _root_ location depends on its type. For a database, the _root_ usually denotes a database or catalog (to use [_information_schema_](https://en.wikipedia.org/wiki/Information_schema) terminology). For object stores, the _root_ is usually the bucket location.
+
+## Scheduling
+
+Recap's crawler does not have a built in scheduler or orchestrator. You can run crawls manually with `recap crawl`, or you can schedule `recap crawl` to run periodically using [cron](https://en.wikipedia.org/wiki/Cron), [Airflow](https://airflow.apache.org), [Prefect](https://prefect.io), [Dagster](https://dagster.io/), [Modal](https://modal.com), or any other scheduler.
+
+## Commands
+
+Run `recap crawl` to begin crawling all configured infrastructure. You may optionall specify a URL to crawl:
+
+    recap crawl postgresql://username@localhost/some_db
+
+See the [commands](commands.md) page for crawler command details.
+
+## Configuration
+
+See the [configuration](configuration.md) page for crawler configuration details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,11 @@ Recap is a dead simple data catalog for engineers.
 
 ## Features
 
-* Crawls metadata for major cloud data warehouses and Postgres
+* Supports major cloud data warehouses and Postgres
 * No external system dependencies to get started
-* CLI-first design
+* Designed for the CLI
 * Runs as a Python library or REST API
-* Pluggable CLI
+* Customizable with plugins
 
 ## Installation
 
@@ -16,11 +16,15 @@ Recap is a dead simple data catalog for engineers.
 
 ## Commands
 
-* `recap api` - Start Recap's REST API.
-* `recap list` - List a data catalog directory.
-* `recap read` - Read metadata from the data catalog.
-* `recap refresh` - Crawl infrastructure and save metadata in the data catalog.
-* `recap search` - Search the data catalog for metadata.
+* `recap catalog list` - List a data catalog directory.
+* `recap catalog read` - Read metadata from the data catalog.
+* `recap catalog search` - Search the data catalog for metadata.
+* `recap crawl` - Crawl infrastructure and save metadata in the data catalog.
+* `recap plugins analyzers` - List all analyzer plugins.
+* `recap plugins browsers` - List all browser plugins.
+* `recap plugins catalogs` - List all catalog plugins.
+* `recap plugins commands` - List all command plugins.
+* `recap serve` - Start Recap's REST API.
 
 ## Getting Started
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,33 @@
+Recap uses Python's standard [logging](https://docs.python.org/3/library/logging.html) library. Logs are printed to standard out using Rich's [logging handler](https://rich.readthedocs.io/en/stable/logging.html) by default.
+
+## Customizing
+
+You can customize Recap's log output. Set the `logging.config.path` value in your `settings.toml` file to point at a [TOML](https://toml.io) file that conforms to Python's [dictConfig](https://docs.python.org/3/library/logging.config.html#logging-config-dictschema) schema.
+
+```toml
+version = 1
+disable_existing_loggers = true
+formatters.standard.format = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+[handlers.default]
+formatter = "standard"
+class = "rich.logging.RichHandler"
+show_time = false
+show_level = false
+show_path = false
+
+[loggers.""]
+handlers = ['default']
+level = "WARNING"
+propagate = false
+
+[loggers.recap]
+handlers = ['default']
+level = "INFO"
+propagate = false
+
+[loggers.uvicorn]
+handlers = ['default']
+level = "INFO"
+propagate = false
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,71 @@
+You can extend Recap with plugins. In fact, everything in Recap is a plugin except for its crawler (and even that might change eventually).
+
+Plugins are implemented using Pythons `entry-points` package metadata. See Python's [using pacakge metadata](https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata) page for more details on this style of plugin architecture.
+
+There are four types of plugins:
+
+* Analyzers
+* Browsers
+* Catalogs
+* Commands
+
+## Analyzers
+
+[Analyzer plugins](analyzers.md) must implement the [AbstractAnalyzer](https://github.com/recap-cloud/recap/blob/main/recap/plugins/analyzers/abstract.py) class.
+
+Packages can export their analyzers using the `recap.analyzers` entrypoint. Here's how Recap's built-in analyzers are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
+
+```toml
+[project.entry-points."recap.analyzers"]
+"db.access" = "recap.plugins.analyzers.table:TableAccessAnalyzer"
+"db.column" = "recap.plugins.analyzers.table:TableColumnAnalyzer"
+"db.comment" = "recap.plugins.analyzers.table:TableCommentAnalyzer"
+"db.foreign_key" = "recap.plugins.analyzers.table:TableForeignKeyAnalyzer"
+"db.index" = "recap.plugins.analyzers.table:TableIndexAnalyzer"
+"db.location" = "recap.plugins.analyzers.table:TableLocationAnalyzer"
+"db.primary_key" = "recap.plugins.analyzers.table:TablePrimaryKeyAnalyzer"
+"db.profile" = "recap.plugins.analyzers.table:TableProfileAnalyzer"
+"db.view_definitions" = "recap.plugins.analyzers.table:TableViewDefinitionAnalyzer"
+```
+
+## Browsers
+
+[Browser plugins](browsers.md) must implement the [AbstractBrowser](https://github.com/recap-cloud/recap/blob/main/recap/plugins/browsers/abstract.py) class.
+
+Packages can export their browsers using the `recap.browsers` entrypoint. Here's how Recap's built-in browser is defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
+
+```toml
+[project.entry-points."recap.browsers"]
+db = "recap.plugins.browsers.db:DatabaseBrowser"
+```
+
+## Catalogs
+
+[Catalog plugins](catalogs.md) must implement the [AbstractCatalog](https://github.com/recap-cloud/recap/blob/main/recap/plugins/catalogs/abstract.py) class.
+
+Packages can export their catalogs using the `recap.catalogs` entrypoint. Here's how Recap's built-in catalogs are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
+
+```toml
+[project.entry-points."recap.catalogs"]
+duckdb = "recap.plugins.catalogs.duckdb:DuckDbCatalog"
+fs = "recap.plugins.catalogs.fs:FilesystemCatalog"
+recap = "recap.plugins.catalogs.recap:RecapCatalog"
+```
+
+## Commands
+
+[Command plugins](commands.md) use [Typer](https://typer.tiangolo.com/). Plugins must expose a `typer.Typer()` object, usually defined as:
+
+```python
+app = typer.Typer()
+```
+
+Packages can export their commands using the `recap.commands` entrypoint. Here's how Recap's built-in commands are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
+
+```toml
+[project.entry-points."recap.commands"]
+catalog = "recap.plugins.commands.catalog:app"
+crawl = "recap.plugins.commands.crawl:app"
+plugins = "recap.plugins.commands.plugins:app"
+serve = "recap.plugins.commands.serve:app"
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,12 +8,12 @@ Start by installing Recap. Python 3.9 or above is required.
 
 Now let's crawl a database:
 
-    recap refresh postgresql://username@localhost/some_db
+    recap crawl postgresql://username@localhost/some_db
 
 You can use any [SQLAlchemy](https://docs.sqlalchemy.org/en/14/dialects/) connect string.
 
-    recap refresh bigquery://some-project-12345
-    recap refresh snowflake://some_user:some_pass@some_account_id
+    recap crawl bigquery://some-project-12345
+    recap crawl snowflake://username:password@account_identifier/SOME_DB/SOME_SCHHEMA?warehouse=SOME_COMPUTE
 
 For Snowflake and BigQuery, you'll have to `pip install snowflake-sqlalchemy` or `pip install sqlalchemy-bigquery`, respectively.
 
@@ -21,7 +21,7 @@ For Snowflake and BigQuery, you'll have to `pip install snowflake-sqlalchemy` or
 
 Crawled metadata is stored in a directory structure. See what's available using:
 
-    recap list /
+    recap catalog list /
 
 Recap will respond with a JSON list:
 
@@ -33,13 +33,13 @@ Recap will respond with a JSON list:
 
 Append children to the path to browse around:
 
-    recap list /databases
+    recap catalog list /databases
 
 ## Read
 
-After you poke around, try and read some metadata. Every node in the path can have metadata, but right now only tables and views do. You can look at metadata using the `recap read` command:
+After you poke around, try and read some metadata. Every node in the path can have metadata, but right now only tables and views do. You can look at metadata using the `recap catalog read` command:
 
-    recap read /databases/postgresql/instances/localhost/schemas/some_db/tables/some_table
+    recap catalog read /databases/postgresql/instances/localhost/schemas/some_db/tables/some_table
 
 Recap will print all of `some_table`'s metadata to the CLI in JSON format:
 
@@ -76,7 +76,7 @@ Recap will print all of `some_table`'s metadata to the CLI in JSON format:
       "type": "BIGINT"
     }
   },
-  "data_profile": {
+  "profile": {
     "email": {
       "count": 10,
       "distinct": 10,
@@ -123,7 +123,6 @@ Recap will print all of `some_table`'s metadata to the CLI in JSON format:
 
 You can search for metadata, too. Recap stores its metadata in [DuckDB](https://duckdb.org) by default, so you can use DuckDB's [JSON path syntax](https://duckdb.org/docs/extensions/json) to search the catalog:
 
-    recap search "metadata->'$.location'->>'$.table' = 'some_table'"
+    recap catalog search "metadata->'$.location'->>'$.table' = 'some_table'"
 
 The database file defaults to `~/.recap/catalog/recap.duckdb`, if you wish to open a DuckDB client directly.
-

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,71 @@
+Recap comes with an HTTP/JSON API server implementation of Recap's [catalog](catalogs.md) interface. The server allows non-Python systems to integrate with Recap. The server also allows metadata to be shared amgonst different systems when they all point to the same server using [Recap's catalog](catalogs.md#recap-catalog).
+
+## Starting
+
+Recap's server starts when the `recap serve` command is executed.
+
+## Configuring
+
+Recap's server is implemented as a [FastAPI](https://fastapi.tiangolo.com/) in a [uvicorn](https://www.uvicorn.org/) web server. Any configuration set in your `settings.toml` file under the `api` namespace will be passed to Recap's `uvicorn.run` invocation.
+
+```toml
+[api]
+host = "192.168.0.1"
+port = 9000
+access_log = false
+```
+
+## Endpoints
+
+Recap has only two endpoints:
+
+* GET `/search` - Search the Recap catalog.
+* GET | PUT | DELETE `/<path>` - Read, write, or remove metadata or directory paths.
+
+Recap's JSON schema is visible at [http://localhost:8000/docs](http://localhost:8000/docs) when you start the server with the `recap server` command. Recap's catalog [source code](https://github.com/recap-cloud/recap/blob/main/recap/plugins/catalogs/recap.py) illustrates how to call Recap server.
+
+!!! note
+
+    Recap's server does not currently have data models for each metadata type; they're just JSON blobs. The JSON schema displays the return type as an `application/json` string.
+
+## Examples
+
+The following examples illlustrate how to call a Recap server running at [http://localhost:8000](http://localhost:8000).
+
+### Read a directory
+
+```bash
+curl http://localhost:8000/databases/postgresql
+```
+
+### Read metadata
+
+```bash
+curl 'http://localhost:8000/databases/postgresql/instances/some_instance/schemas/some_db/tables/some_table?read=true'
+```
+
+### Write a directory
+
+```bash
+curl -X PUT http://localhost:8000/databases/postgresql/instances/some_instance/schemas/some_db/tables
+```
+
+### Write metadata
+
+```bash
+curl -X PUT 'http://localhost:8000/databases/postgresql/instances/some_instance/schemas/some_db/tables/some_table?type=some_metadata_type' \
+  -d '{"some_metadata_type": {"metadata_key": "metadata_value"}}' \
+  -H "Content-Type: application/json"
+```
+
+### Delete a directory
+
+```bash
+curl -X DELETE http://localhost:8000/databases/postgresql
+```
+
+### Delete metadata
+
+```bash
+curl -X DELETE 'http://localhost:8000/databases/postgresql/instances/some_instance/schemas/some_db/tables/some_table?type=some_metadata_type'
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,13 +8,15 @@ edit_uri: 'https://github.com/recap-cloud/recap/tree/main/docs'
 nav:
     - Home: index.md
     - Quickstart: quickstart.md
-#    - CLI: cli.md
-#    - Crawlers: crawlers.md
-#    - Catalog: catalogs.md
-#    - API: api.md
-#    - Configuration: configuration.md
-#    - Logs: logs.md
-#    - Plugins: plugins.md
+    - Commands: commands.md
+    - Crawler: crawler.md
+    - Browsers: browsers.md
+    - Analyzers: analyzers.md
+    - Catalogs: catalogs.md
+    - Server: server.md
+    - Configuration: configuration.md
+    - Logging: logging.md
+    - Plugins: plugins.md
 theme:
   features:
       - search.suggest

--- a/recap/plugins/catalogs/abstract.py
+++ b/recap/plugins/catalogs/abstract.py
@@ -51,11 +51,6 @@ class AbstractCatalog(ABC):
         raise NotImplementedError
 
     @staticmethod
-    @abstractmethod
-    def openable(url: str) -> bool:
-        raise NotImplementedError
-
-    @staticmethod
     @contextmanager
     @abstractmethod
     def open(**config) -> Generator['AbstractCatalog', None, None]:

--- a/recap/plugins/catalogs/duckdb.py
+++ b/recap/plugins/catalogs/duckdb.py
@@ -157,11 +157,6 @@ class DuckDbCatalog(AbstractCatalog):
         return json.loads(maybe_row[0]) if maybe_row else None # pyright: ignore [reportGeneralTypeIssues]
 
     @staticmethod
-    def openable(url: str) -> bool:
-        from urllib.parse import urlparse
-        return urlparse(url).scheme.split('+')[0] == 'file'
-
-    @staticmethod
     @contextmanager
     def open(**config) -> Generator['DuckDbCatalog', None, None]:
         url = urlparse(config.get('url', DEFAULT_URL))

--- a/recap/plugins/catalogs/fs.py
+++ b/recap/plugins/catalogs/fs.py
@@ -1,5 +1,6 @@
 import fsspec
 import json
+import logging
 import pyjq
 from .abstract import AbstractCatalog
 from contextlib import contextmanager
@@ -10,6 +11,7 @@ from urllib.parse import urlparse
 
 
 DEFAULT_URL = f"file://{settings('root_path', RECAP_HOME)}/catalog"
+log = logging.getLogger(__name__)
 
 
 class FilesystemCatalog(AbstractCatalog):


### PR DESCRIPTION
I've filled out the documentation a bit more. It's still very light, but I've at least added sections for all the main components in Recap. I still feel like a `concepts` section that explains Recap's directory and metadata structure is worth writing, but I'll save that for later.