### PR TITLE
Link README and docs to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@
 <i>A dead simple data catalog for engineers</i>
 </p>
 
+## About
+
+Recap makes it easy for engineers to build infrastructure and tools that need metadata. Unlike traditional data catalogs, Recap is designed to power software. Read [Recap: A Data Catalog for People Who Hate Data Catalogs](https://cnr.sh/essays/recap-for-people-who-hate-data-catalogs) to learn more.
+
 ## Features
 
 * Supports major cloud data warehouses and Postgres
-* No external system dependencies to get started
-* Designed for the CLI
-* Runs as a Python library or REST API
-* Customizable with plugins
+* No external system dependencies required
+* Designed for the [CLI](https://docs.recap.cloud/latest/commands/)
+* Runs as a Python library or [REST API](https://docs.recap.cloud/latest/server/)
+* Fully [pluggable](https://docs.recap.cloud/latest/plugins/)
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 # Recap
 
-Recap is a dead simple data catalog for engineers.
+Recap makes it easy for engineers to build infrastructure and tools that need metadata. Unlike traditional data catalogs, Recap is designed to power software. Read [Recap: A Data Catalog for People Who Hate Data Catalogs](https://cnr.sh/essays/recap-for-people-who-hate-data-catalogs) to learn more.
 
 ## Features
 
 * Supports major cloud data warehouses and Postgres
-* No external system dependencies to get started
-* Designed for the CLI
-* Runs as a Python library or REST API
-* Customizable with plugins
+* No external system dependencies required
+* Designed for the [CLI](commands.md)
+* Runs as a Python library or [REST API](server.md)
+* Fully [pluggable](plugins.md)
 
 ## Installation
 


### PR DESCRIPTION
I'm adding a link to my blog post, which explains I wrote Recap. Hopefully, this context will explain why yet-another-data-catalog is being forced upon the world.