### PR TITLE
Store versioned metadata in DatabaseCatalog

### DIFF
--- a/recap/plugins/commands/catalog.py
+++ b/recap/plugins/commands/catalog.py
@@ -42,5 +42,5 @@ def read(
     """
 
     with catalogs.open(**settings('catalog', {})) as c:
-        results = c.read(PurePosixPath(path))
+        results = c.read(PurePosixPath(path)) or []
         print_json(data=results, sort_keys=True)


### PR DESCRIPTION
This is a half-way-done commit, but I don't want the PR to get too big. I've updated DatabaseCatalog to store all previous versions of metadata. I've also added a deleted_at tombstone to track deletions. Lastly, I added an optimization to the touch() method to skip parents once we discover a child already exists.

I haven't updated AbstractCatalog and the HTTP API to expose as_of yet.