### PR TITLE
Add metadata time traveling

### DIFF
--- a/recap/plugins/catalogs/abstract.py
+++ b/recap/plugins/catalogs/abstract.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import PurePosixPath
 from typing import Any, Generator, List
 
@@ -58,6 +59,7 @@ class AbstractCatalog(ABC):
     def ls(
         self,
         path: PurePosixPath,
+        as_of: datetime | None = None,
     ) -> List[str] | None:
         """
         Returns all children in a directory. This method does not signal
@@ -73,6 +75,7 @@ class AbstractCatalog(ABC):
     def read(
         self,
         path: PurePosixPath,
+        as_of: datetime | None = None,
     ) -> dict[str, Any] | None:
         """
         Read all metadata in a directory.
@@ -86,6 +89,7 @@ class AbstractCatalog(ABC):
     def search(
         self,
         query: str,
+        as_of: datetime | None = None,
     ) -> List[dict[str, Any]]:
         """
         Searches an entire catalog for metadata. The query syntax is dependent

--- a/recap/plugins/catalogs/recap.py
+++ b/recap/plugins/catalogs/recap.py
@@ -1,6 +1,7 @@
 import httpx
 from .abstract import AbstractCatalog
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import PurePosixPath
 from recap.plugins.commands.serve import DEFAULT_URL
 from typing import Any, List, Generator
@@ -43,20 +44,32 @@ class RecapCatalog(AbstractCatalog):
     def ls(
         self,
         path: PurePosixPath,
+        as_of: datetime | None = None,
     ) -> List[str] | None:
-        return self.client.get(str(path)).json()
+        params: dict[str, Any] = {}
+        if as_of:
+            params['as_of'] = as_of.isoformat()
+        return self.client.get(str(path), params=params).json()
 
     def read(
         self,
         path: PurePosixPath,
+        as_of: datetime | None = None,
     ) -> dict[str, Any] | None:
-        return self.client.get(str(path), params={'read': True}).json()
+        params: dict[str, Any] = {'read': True}
+        if as_of:
+            params['as_of'] = as_of.isoformat()
+        return self.client.get(str(path), params=params).json()
 
     def search(
         self,
         query: str,
+        as_of: datetime | None = None,
     ) -> List[dict[str, Any]]:
-        return self.client.get('/search', params={'query': query}).json()
+        params: dict[str, Any] = {'query': query}
+        if as_of:
+            params['as_of'] = as_of.isoformat()
+        return self.client.get('/search', params=params).json()
 
     @staticmethod
     @contextmanager

--- a/recap/plugins/commands/catalog.py
+++ b/recap/plugins/commands/catalog.py
@@ -1,4 +1,5 @@
 import typer
+from datetime import datetime
 from recap.plugins import catalogs
 from recap.config import settings
 from rich import print_json
@@ -9,38 +10,55 @@ app = typer.Typer(help="Read and search the data catalog.")
 
 
 @app.command()
-def search(query: str):
+def search(
+    query: str,
+    as_of: datetime = typer.Option(
+        None, '--as-of', '-a',
+        help=\
+            "View metadata as of a point in time.",
+    ),
+):
     """
     Searches the data catalog. The query string syntax is dependent on the data
     catalog.
     """
 
     with catalogs.open(**settings('catalog', {})) as c:
-        results = c.search(query)
+        results = c.search(query, as_of)
         print_json(data=results, sort_keys=True)
 
 
 @app.command("list")
 def list_(
-    path: str = typer.Argument('/')
+    path: str = typer.Argument('/'),
+    as_of: datetime = typer.Option(
+        None, '--as-of', '-a',
+        help=\
+            "View metadata as of a point in time.",
+    ),
 ):
     """
     Lists a data catalog directory's children.
     """
 
     with catalogs.open(**settings('catalog', {})) as c:
-        results = sorted(c.ls(PurePosixPath(path)) or [])
+        results = sorted(c.ls(PurePosixPath(path), as_of) or [])
         print_json(data=results)
 
 
 @app.command()
 def read(
-    path: str
+    path: str,
+    as_of: datetime = typer.Option(
+        None, '--as-of', '-a',
+        help=\
+            "View metadata as of a point in time.",
+    ),
 ):
     """
     Prints metadata from a path in the data catalog.
     """
 
     with catalogs.open(**settings('catalog', {})) as c:
-        results = c.read(PurePosixPath(path)) or []
+        results = c.read(PurePosixPath(path), as_of) or []
         print_json(data=results, sort_keys=True)

--- a/recap/plugins/commands/serve.py
+++ b/recap/plugins/commands/serve.py
@@ -1,4 +1,5 @@
 import typer
+from datetime import datetime
 from fastapi import Body, Depends, FastAPI
 from pathlib import PurePosixPath
 from typing import Any, List, Generator
@@ -23,9 +24,10 @@ def get_catalog() -> Generator[AbstractCatalog, None, None]:
 @fastapp.get("/search")
 def query_search(
     query: str,
+    as_of: datetime | None = None,
     catalog: AbstractCatalog = Depends(get_catalog),
 ) -> List[dict[str, Any]]:
-    return catalog.search(query)
+    return catalog.search(query, as_of)
 
 
 @fastapp.get("/{path:path}")
@@ -33,13 +35,14 @@ def get_path(
     # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
     path: str,
     read: bool | None = None,
+    as_of: datetime | None = None,
     catalog: AbstractCatalog = Depends(get_catalog),
 ) -> List[str] | dict[str, Any]:
     # TODO should probably return a 404 if we get None from storage
     if read:
-        return catalog.read(PurePosixPath(path)) or {}
+        return catalog.read(PurePosixPath(path), as_of) or {}
     else:
-        return catalog.ls(PurePosixPath(path)) or []
+        return catalog.ls(PurePosixPath(path), as_of) or []
 
 
 @fastapp.put("/{path:path}")


### PR DESCRIPTION
Recap now supports time traveling when browsing the catalog. Users can provide an `--as-of` timestamp to see what databases, tables, schemas, and metadata looked like at a point in time. Let's look at some CLI examples!

List tables as of 2022-12-01:

    recap catalog list \
        /databases/postgresql/instances/localhost/schemas/public/tables \
        --aa-of '2022-12-01'

Read the metadata for `table` as it looked on 2022-12-10 01:01:01:

    recap catalog read \
        /databases/postgresql/instances/localhost/schemas/public/tables/table \
        --as-of '2022-12-10 01:01:01'

Search for all table metadata in `some_db` as it looked on 2022-10-12 04:23:43:

    recap catalog search \
        "json_extract(metadata, '$.location.schema') = 'some_db'" \
        --as-of '2022-10-12 04:23:43'

Of course, these changes flow through to AbstractCatalog, DatabaseCatalog, and RecapCatalog as well. I also had to update the FastAPI server to support `as_of` query parameters.

The FilesystemCatalog is well and busted right now. I'll need to fix that or ditch it. Saving that for a subsequent PR.