### PR TITLE
Remove analyzable and browsable from analyzers and browsers

### DIFF
--- a/recap/analyzers/abstract.py
+++ b/recap/analyzers/abstract.py
@@ -10,32 +10,6 @@ class AbstractAnalyzer(ABC):
     inspecting data and returning metadata.
     """
 
-    @staticmethod
-    @abstractmethod
-    def analyzable(url: str) -> bool:
-        """
-        Determine if this analyzer can analyze data from a given infrastructure
-        instance. In plain english, `analyzable` answers the question "Can
-        FooAnalyzer collect metadata from
-        'postgresql://user:pass@localhost/some_db'"?
-
-        `analyzable` is called before the analyzer is instantiated. If it
-        returns False, the analyzer is skipped.
-
-        :param url: The instance URL that to be analyzed. This URL points to
-            the base of the instance; it doesn't include a path to specific
-            data. For example, it would look like
-            "postgresql://user:pass@localhost/some_db", rather than
-            "postgresql://user:pass@localhost/some_db/some_schema/some_table".
-
-            `analyzable` will be called once, then `analyze()` will be called
-            multiple times, once for each path to data.
-        :returns: True if the analyzer is compatible with the given URL, else
-            False.
-        """
-
-        raise NotImplementedError
-
     @abstractmethod
     def analyze(self, path: PurePosixPath) -> dict[str, Any]:
         """

--- a/recap/analyzers/db.py
+++ b/recap/analyzers/db.py
@@ -18,17 +18,6 @@ class AbstractDatabaseAnalyzer(AbstractAnalyzer):
     ):
         self.engine = engine
 
-    @staticmethod
-    def analyzable(url: str) -> bool:
-        # TODO there's probably a better way to do this.
-        # Seems like SQLAlchemy should have a method to check dialects.
-        try:
-            sa.create_engine(url)
-            return True
-        except Exception as e:
-            log.debug('Unanalyzable. Create engine failed for url=%s', url)
-            return False
-
     def analyze(self, path: PurePosixPath) -> dict[str, Any]:
         database_path = DatabasePath(path)
         schema = database_path.schema

--- a/recap/browsers/abstract.py
+++ b/recap/browsers/abstract.py
@@ -30,31 +30,6 @@ class AbstractBrowser(ABC):
     Something like 'postgresql://user:pass@localhost/my_db`.
     """
 
-    @staticmethod
-    @abstractmethod
-    def browsable(url: str) -> bool:
-        """
-        Determine if this browser can browse a given infrastructure instance.
-        In plain english, `browsable` answers the question "Can FooBrowser
-        return directory lists for 'postgresql://user:pass@localhost/some_db'"?
-
-        `browsable` is called before the browser is instantiated. If it
-        returns False, the browser is skipped.
-
-        :param url: The instance URL that will be browsed. This URL points to
-            the base of the instance; it doesn't include a path to specific
-            data. For example, it would look like
-            "postgresql://user:pass@localhost/some_db", rather than
-            "postgresql://user:pass@localhost/some_db/some_schema/some_table".
-
-            `browsable` will be called once, then `children()` will be called
-            multiple times, once for each path to data.
-        :returns: True if the browser is compatible with the given URL, else
-            False.
-        """
-
-        raise NotImplementedError
-
     @abstractmethod
     def children(self, path: PurePosixPath) -> List[str]:
         """

--- a/recap/browsers/db.py
+++ b/recap/browsers/db.py
@@ -157,21 +157,6 @@ class DatabaseBrowser(AbstractBrowser):
         )
 
     @staticmethod
-    def browsable(url: str) -> bool:
-        """
-        :returns: True if a SQLAlchemy engine can be created, else False.
-        """
-
-        # TODO there's probably a better way to do this.
-        # Seems like SQLAlchemy should have a method to check dialects.
-        try:
-            sa.create_engine(url)
-            return True
-        except Exception as e:
-            log.debug('Unbrowsable. Create engine failed for url=%s', url)
-            return False
-
-    @staticmethod
     @contextmanager
     def open(**config) -> Generator['DatabaseBrowser', None, None]:
         assert 'url' in config, \

--- a/recap/crawler.py
+++ b/recap/crawler.py
@@ -207,18 +207,32 @@ class Crawler:
 
         with ExitStack() as stack:
             for analyzer_name, analyzer_cls in analyzer_plugins.items():
-                if (
-                    analyzer_cls.analyzable(url)
-                    and analyzer_name not in excludes
-                ):
-                    analyzer_context_manager = analyzer_cls.open(**config)
-                    analyzer = stack.enter_context(analyzer_context_manager)
-                    analyzers.append(analyzer)
+                if (analyzer_name not in excludes):
+                    try:
+                        analyzer_context_manager = analyzer_cls.open(**config)
+                        analyzer = stack.enter_context(
+                            analyzer_context_manager,
+                        )
+                        analyzers.append(analyzer)
+                    except:
+                        log.debug(
+                            'Skipped analyzer for url=%s name=%s class=%s',
+                            url,
+                            analyzer_name,
+                            analyzer_cls,
+                        )
 
-            for browser_cls in browser_plugins.values():
-                if browser_cls.browsable(url):
+            for browser_name, browser_cls in browser_plugins.items():
+                try:
                     browser_context_manager = browser_cls.open(**config)
                     browser = stack.enter_context(browser_context_manager)
+                except:
+                        log.debug(
+                            'Skipped browser for url=%s name=%s class=%s',
+                            url,
+                            browser_name,
+                            browser_cls,
+                        )
 
             assert analyzers, f"Found no analyzers for url={url}"
             assert browser, f"Found no browser for url={url}"


### PR DESCRIPTION
I decided it's cleaner to optimistically call `open()` and catch exceptions if analyzers and browsers can't open a URL. The AbstractBrowser and AbstractAnalyzer classes are a bit simpler now.