### PR TITLE
Add FastAPI router plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,18 +2,19 @@ You can extend Recap with plugins. In fact, everything in Recap is a plugin exce
 
 Plugins are implemented using Pythons `entry-points` package metadata. See Python's [using pacakge metadata](https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata) page for more details on this style of plugin architecture.
 
-There are four types of plugins:
+There are five types of plugins:
 
 * Analyzers
 * Browsers
 * Catalogs
 * Commands
+* Routers
 
 ## Analyzers
 
 [Analyzer plugins](analyzers.md) must implement the [AbstractAnalyzer](https://github.com/recap-cloud/recap/blob/main/recap/plugins/analyzers/abstract.py) class.
 
-Packages can export their analyzers using the `recap.analyzers` entrypoint. Here's how Recap's built-in analyzers are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
+Packages can export their analyzers using the `recap.analyzers` entry-point. Here's how Recap's built-in analyzers are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
 
 ```toml
 [project.entry-points."recap.analyzers"]
@@ -32,7 +33,7 @@ Packages can export their analyzers using the `recap.analyzers` entrypoint. Here
 
 [Browser plugins](browsers.md) must implement the [AbstractBrowser](https://github.com/recap-cloud/recap/blob/main/recap/plugins/browsers/abstract.py) class.
 
-Packages can export their browsers using the `recap.browsers` entrypoint. Here's how Recap's built-in browser is defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
+Packages can export their browsers using the `recap.browsers` entry-point. Here's how Recap's built-in browser is defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
 
 ```toml
 [project.entry-points."recap.browsers"]
@@ -43,7 +44,7 @@ db = "recap.browsers.db:DatabaseBrowser"
 
 [Catalog plugins](catalogs.md) must implement the [AbstractCatalog](https://github.com/recap-cloud/recap/blob/main/recap/plugins/catalogs/abstract.py) class.
 
-Packages can export their catalogs using the `recap.catalogs` entrypoint. Here's how Recap's built-in catalogs are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
+Packages can export their catalogs using the `recap.catalogs` entry-point. Here's how Recap's built-in catalogs are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
 
 ```toml
 [project.entry-points."recap.catalogs"]
@@ -59,7 +60,7 @@ recap = "recap.catalogs.recap:RecapCatalog"
 app = typer.Typer()
 ```
 
-Packages can export their commands using the `recap.commands` entrypoint. Here's how Recap's built-in commands are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
+Packages can export their commands using the `recap.commands` entry-point. Here's how Recap's built-in commands are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
 
 ```toml
 [project.entry-points."recap.commands"]
@@ -68,3 +69,28 @@ crawl = "recap.commands.crawl:app"
 plugins = "recap.commands.plugins:app"
 serve = "recap.commands.serve:app"
 ```
+
+## Routers
+
+[Server plugins](server.md) use [FastAPI](https://fastapi.tiangolo.com/). Plugins must expose a `fastapi.APIRouter()` object, usually defined as:
+
+```python
+router = fastapi.APIRouter()
+```
+
+Packages can export their commands using the `recap.routers` entry-point. Here's how Recap's built-in routers are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
+
+```toml
+[project.entry-points."recap.routers"]
+recap = "recap.routers.recap:router"
+```
+
+Routers are added relative to the HTTP server's root path.
+
+!!! tip
+
+    Recap calls `include_router(route)` for each object in the `recap.routers` entry-point. This means that anything that works with `include_router` can be exposed (even [GraphQL APIs](https://fastapi.tiangolo.com/advanced/graphql/)).
+
+!!! warning
+
+    [Order matters](https://fastapi.tiangolo.com/tutorial/path-params/#order-matters) when adding routers to FastAPI. Recap does not currently support router order prioritization; routers are added in an unpredictable order. If multiple routers contain the same path, the first one will handle incoming requests to its path.

--- a/docs/server.md
+++ b/docs/server.md
@@ -20,7 +20,8 @@ access_log = false
 Recap has only two endpoints:
 
 * GET `/search` - Search the Recap catalog.
-* GET | PUT | DELETE `/<path>` - Read, write, or remove metadata or directory paths.
+* GET | PUT | DELETE `/directory/<path>` - Read, write, or remove a directory path.
+* GET | PATCH | DELETE `/metadata/<path>` - Read, write, or remove metadata.
 
 Recap's JSON schema is visible at [http://localhost:8000/docs](http://localhost:8000/docs) when you start the server with the `recap server` command. Recap's catalog [source code](https://github.com/recap-cloud/recap/blob/main/recap/plugins/catalogs/recap.py) illustrates how to call Recap server.
 
@@ -35,25 +36,25 @@ The following examples illlustrate how to call a Recap server running at [http:/
 ### Read a directory
 
 ```bash
-curl http://localhost:8000/databases/postgresql
+curl http://localhost:8000/directory/databases/postgresql
 ```
 
 ### Read metadata
 
 ```bash
-curl 'http://localhost:8000/databases/postgresql/instances/some_instance/schemas/some_db/tables/some_table?read=true'
+curl 'http://localhost:8000/metadata/databases/postgresql/instances/some_instance/schemas/some_db/tables/some_table?read=true'
 ```
 
 ### Write a directory
 
 ```bash
-curl -X PUT http://localhost:8000/databases/postgresql/instances/some_instance/schemas/some_db/tables
+curl -X PUT http://localhost:8000/directory/databases/postgresql/instances/some_instance/schemas/some_db/tables
 ```
 
 ### Write metadata
 
 ```bash
-curl -X PUT 'http://localhost:8000/databases/postgresql/instances/some_instance/schemas/some_db/tables/some_table?type=some_metadata_type' \
+curl -X PATCH 'http://localhost:8000/metadata/databases/postgresql/instances/some_instance/schemas/some_db/tables/some_table?type=some_metadata_type' \
   -d '{"some_metadata_type": {"metadata_key": "metadata_value"}}' \
   -H "Content-Type: application/json"
 ```
@@ -61,11 +62,11 @@ curl -X PUT 'http://localhost:8000/databases/postgresql/instances/some_instance/
 ### Delete a directory
 
 ```bash
-curl -X DELETE http://localhost:8000/databases/postgresql
+curl -X DELETE http://localhost:8000/directory/databases/postgresql
 ```
 
 ### Delete metadata
 
 ```bash
-curl -X DELETE 'http://localhost:8000/databases/postgresql/instances/some_instance/schemas/some_db/tables/some_table?type=some_metadata_type'
+curl -X DELETE 'http://localhost:8000/metadata/databases/postgresql/instances/some_instance/schemas/some_db/tables/some_table?type=some_metadata_type'
 ```

--- a/pdm.lock
+++ b/pdm.lock
@@ -48,7 +48,7 @@ summary = "The dynamic configurator for your Python Project"
 
 [[package]]
 name = "fastapi"
-version = "0.88.0"
+version = "0.89.1"
 requires_python = ">=3.7"
 summary = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 dependencies = [
@@ -505,9 +505,9 @@ content_hash = "sha256:a33e1b8caeaffce64b87fdda278754ae730aa259e8110205218c34862
     {url = "https://files.pythonhosted.org/packages/54/6f/09c3ca2943314e0cae5cb2eeca1b77f5968855e13d6fdaae32c8e055eb7c/dynaconf-3.1.11.tar.gz", hash = "sha256:d9cfb50fd4a71a543fd23845d4f585b620b6ff6d9d3cc1825c614f7b2097cb39"},
     {url = "https://files.pythonhosted.org/packages/e7/67/0600b5fbd27928c112a11a5018b3e9ebf3d7f896d510c3c231f8d09886ae/dynaconf-3.1.11-py2.py3-none-any.whl", hash = "sha256:87e0b3b12b5db9e8fb465e1f8c7fdb926cd2ec5b6d88aa7f821f316df93fb165"},
 ]
-"fastapi 0.88.0" = [
-    {url = "https://files.pythonhosted.org/packages/d8/09/ce090f6d53ce8b6335954488087210fa1e054c4a65f74d5f76aed254c159/fastapi-0.88.0-py3-none-any.whl", hash = "sha256:263b718bb384422fe3d042ffc9a0c8dece5e034ab6586ff034f6b4b1667c3eee"},
-    {url = "https://files.pythonhosted.org/packages/f0/d1/55559f6b09ac336cbb4640ab4c2da0fd79a955eed31f475f0a5ba2ad102e/fastapi-0.88.0.tar.gz", hash = "sha256:915bf304180a0e7c5605ec81097b7d4cd8826ff87a02bb198e336fb9f3b5ff02"},
+"fastapi 0.89.1" = [
+    {url = "https://files.pythonhosted.org/packages/09/b3/d259ee31dfe35e583a629f39b16047a9afe455694403bf51510981414721/fastapi-0.89.1.tar.gz", hash = "sha256:15d9271ee52b572a015ca2ae5c72e1ce4241dd8532a534ad4f7ec70c376a580f"},
+    {url = "https://files.pythonhosted.org/packages/8f/89/adf4525d1870021b65ec562e83e9f46d96494ad95f238d0264ef1ab6b604/fastapi-0.89.1-py3-none-any.whl", hash = "sha256:f9773ea22290635b2f48b4275b2bf69a8fa721fda2e38228bed47139839dc877"},
 ]
 "ghp-import 2.1.0" = [
     {url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ crawl = "recap.commands.crawl:app"
 plugins = "recap.commands.plugins:app"
 serve = "recap.commands.serve:app"
 
+[project.entry-points."recap.routers"]
+recap = "recap.routers.recap:router"
+
 [build-system]
 requires = ["pdm-pep517>=1.0.0"]
 build-backend = "pdm.pep517.api"

--- a/recap/commands/serve.py
+++ b/recap/commands/serve.py
@@ -1,72 +1,10 @@
 import typer
-from datetime import datetime
-from fastapi import Body, Depends, FastAPI
-from pathlib import PurePosixPath
-from typing import Any, List, Generator
-from recap import catalogs
-from recap.catalogs.abstract import AbstractCatalog
 from recap.config import settings
 from recap.logging import setup_logging
+from recap.server import fastapp
 
-
-DEFAULT_URL = 'http://localhost:8000'
 
 app = typer.Typer()
-fastapp = FastAPI()
-
-
-def get_catalog() -> Generator[AbstractCatalog, None, None]:
-    with catalogs.open(**settings('catalog', {})) as c:
-        yield c
-
-
-# WARN This must go before get_path since get_path is a catch-all.
-@fastapp.get("/search")
-def query_search(
-    query: str,
-    as_of: datetime | None = None,
-    catalog: AbstractCatalog = Depends(get_catalog),
-) -> List[dict[str, Any]]:
-    return catalog.search(query, as_of)
-
-
-@fastapp.get("/{path:path}")
-def get_path(
-    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
-    path: str,
-    read: bool | None = None,
-    as_of: datetime | None = None,
-    catalog: AbstractCatalog = Depends(get_catalog),
-) -> List[str] | dict[str, Any]:
-    # TODO should probably return a 404 if we get None from storage
-    if read:
-        return catalog.read(PurePosixPath(path), as_of) or {}
-    else:
-        return catalog.ls(PurePosixPath(path), as_of) or []
-
-
-@fastapp.put("/{path:path}")
-def put_path(
-    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
-    path: str,
-    type: str | None = None,
-    metadata: Any = Body(default=None),
-    catalog: AbstractCatalog = Depends(get_catalog),
-):
-    if type and metadata:
-        catalog.write(PurePosixPath(path), type, metadata)
-    else:
-        return catalog.touch(PurePosixPath(path))
-
-
-@fastapp.delete("/{path:path}")
-def delete_path(
-    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
-    path: str,
-    type: str | None = None,
-    catalog: AbstractCatalog = Depends(get_catalog),
-):
-    catalog.rm(PurePosixPath(path), type)
 
 
 @app.command()

--- a/recap/plugins.py
+++ b/recap/plugins.py
@@ -4,6 +4,7 @@ import sys
 from .analyzers.abstract import AbstractAnalyzer
 from .browsers.abstract import AbstractBrowser
 from .catalogs.abstract import AbstractCatalog
+from fastapi import APIRouter
 from typing import Type
 
 
@@ -20,6 +21,7 @@ ANALYZER_PLUGIN_GROUP = 'recap.analyzers'
 BROWSER_PLUGIN_GROUP = 'recap.browsers'
 CATALOG_PLUGIN_GROUP = 'recap.catalogs'
 COMMAND_PLUGIN_GROUP = 'recap.commands'
+ROUTER_PLUGIN_GROUP = 'recap.routers'
 
 
 def load_analyzer_plugins() -> dict[str, Type[AbstractAnalyzer]]:
@@ -79,12 +81,29 @@ def load_command_plugins() -> dict[str, typer.Typer]:
     for command_plugin in command_plugins:
         command_plugin_name = command_plugin.name
         try:
-            command_plugin_class = command_plugin.load()
-            plugins[command_plugin_name] = command_plugin_class
+            command_plugin_instance = command_plugin.load()
+            plugins[command_plugin_name] = command_plugin_instance
         except ImportError as e:
             log.debug(
                 "Skipping command=%s due to import error.",
                 command_plugin_name,
+                exc_info=e,
+            )
+    return plugins
+
+
+def load_router_plugins() -> dict[str, APIRouter]:
+    plugins = {}
+    router_plugins = entry_points(group=ROUTER_PLUGIN_GROUP)
+    for router_plugin in router_plugins:
+        router_plugin_name = router_plugin.name
+        try:
+            router_plugin_instance = router_plugin.load()
+            plugins[router_plugin_name] = router_plugin_instance
+        except ImportError as e:
+            log.debug(
+                "Skipping router=%s due to import error.",
+                router_plugin_name,
                 exc_info=e,
             )
     return plugins

--- a/recap/routers/recap.py
+++ b/recap/routers/recap.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pathlib import PurePosixPath
+from typing import Any, List
+from recap.catalogs.abstract import AbstractCatalog
+from recap.server import get_catalog
+
+
+router = APIRouter()
+
+# WARN This must go before get_path since get_path is a catch-all.
+@router.get("/search")
+def query_search(
+    query: str,
+    as_of: datetime | None = None,
+    catalog: AbstractCatalog = Depends(get_catalog),
+) -> List[dict[str, Any]]:
+    return catalog.search(query, as_of)
+
+
+@router.get("/directory/{path:path}")
+def list_directory(
+    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
+    path: str,
+    as_of: datetime | None = None,
+    catalog: AbstractCatalog = Depends(get_catalog),
+) -> List[str]:
+    children = catalog.ls(PurePosixPath(path), as_of)
+    if children:
+        return children
+    raise HTTPException(status_code=404)
+
+
+@router.put("/directory/{path:path}")
+def make_directory(
+    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
+    path: str,
+    catalog: AbstractCatalog = Depends(get_catalog),
+):
+    catalog.touch(PurePosixPath(path))
+
+
+@router.delete("/directory/{path:path}")
+def remove_directory(
+    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
+    path: str,
+    catalog: AbstractCatalog = Depends(get_catalog),
+):
+    catalog.rm(PurePosixPath(path))
+
+
+@router.get("/metadata/{path:path}")
+def read_metadata(
+    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
+    path: str,
+    as_of: datetime | None = None,
+    catalog: AbstractCatalog = Depends(get_catalog),
+) -> dict[str, Any]:
+    # TODO should probably return a 404 if we get None from storage
+    metadata = catalog.read(PurePosixPath(path), as_of)
+    if metadata:
+        return metadata
+    raise HTTPException(status_code=404)
+
+
+@router.patch("/metadata/{path:path}")
+def patch_metadata(
+    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
+    path: str,
+    type: str,
+    metadata: Any = Body(),
+    catalog: AbstractCatalog = Depends(get_catalog),
+):
+    catalog.write(PurePosixPath(path), type, metadata)
+
+
+@router.delete("/metadata/{path:path}")
+def delete_metadata(
+    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
+    path: str,
+    type: str | None = None,
+    catalog: AbstractCatalog = Depends(get_catalog),
+):
+    catalog.rm(PurePosixPath(path), type)
+
+

--- a/recap/server.py
+++ b/recap/server.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from typing import Generator
+from . import catalogs, plugins
+from recap.catalogs.abstract import AbstractCatalog
+from recap.config import settings
+
+
+DEFAULT_URL = 'http://localhost:8000'
+
+
+fastapp = FastAPI()
+
+
+def get_catalog() -> Generator[AbstractCatalog, None, None]:
+    with catalogs.open(**settings('catalog', {})) as c:
+        yield c
+
+
+@fastapp.on_event("startup")
+def load_plugins():
+    router_plugins = plugins.load_router_plugins()
+    for plugin_router in router_plugins.values():
+        fastapp.include_router(plugin_router)


### PR DESCRIPTION
I've made Recap's FastAPI server pluggable. I also moved Recap's built-in HTTP endpoints to a plugin route called `recap`, which is exposed in the `recap.routers` entry-point in `pyproject.toml`.

As part of this change, I also changed the directory and metadata paths so they're not naked on the root. Directory paths now starts with `/directory` and metdata paths start with `/metadata`.

The docs have been updated as well.

Closes #53