### PR TITLE
Recap requires Python 3.10

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 ## Install
 
-Start by installing Recap. Python 3.9 or above is required.
+Start by installing Recap. Python 3.10 or above is required.
 
     pip install recap-core
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ dependencies = [
     "setuptools>=65.6.3",
     "tomli>=2.0.1",
 ]
-# <3.11 to make Recap work with sqlalchemy-bigquery
-requires-python = ">=3.9, <3.11"
+requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "MIT"}
 keywords = [

--- a/recap/catalogs/abstract.py
+++ b/recap/catalogs/abstract.py
@@ -47,7 +47,7 @@ class AbstractCatalog(ABC):
         type: str | None = None,
     ):
         """
-        Remove a directory or metadata entry. If type  is note set, the whole
+        Remove a directory or metadata entry. If type is note set, the whole
         directory (including all children and metadata) is removed.
 
         :param type: If specified, the type of metadata to delete.

--- a/recap/routers/recap.py
+++ b/recap/routers/recap.py
@@ -8,16 +8,6 @@ from recap.server import get_catalog
 
 router = APIRouter()
 
-# WARN This must go before get_path since get_path is a catch-all.
-@router.get("/search")
-def query_search(
-    query: str,
-    as_of: datetime | None = None,
-    catalog: AbstractCatalog = Depends(get_catalog),
-) -> List[dict[str, Any]]:
-    return catalog.search(query, as_of)
-
-
 @router.get("/directory/{path:path}")
 def list_directory(
     # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
@@ -84,3 +74,10 @@ def delete_metadata(
     catalog.rm(PurePosixPath(path), type)
 
 
+@router.get("/search")
+def query_search(
+    query: str,
+    as_of: datetime | None = None,
+    catalog: AbstractCatalog = Depends(get_catalog),
+) -> List[dict[str, Any]]:
+    return catalog.search(query, as_of)


### PR DESCRIPTION
pipe operator all over, which was added in 3.10.  I would also like to use Python's pattern matching, which was added in 3.10. Excluding 3.9 will probably exclude some users, but frankly, they're so use to Python version abuse, they should be able to navigate this change.

Closes #88