### PR TITLE
Remove `url` from AbstractBrowser

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -131,15 +131,6 @@ requires_python = ">=3.5"
 summary = "Internationalized Domain Names in Applications (IDNA)"
 
 [[package]]
-name = "importlib-metadata"
-version = "5.2.0"
-requires_python = ">=3.7"
-summary = "Read metadata from Python packages"
-dependencies = [
-    "zipp>=0.5",
-]
-
-[[package]]
 name = "jinja2"
 version = "3.1.2"
 requires_python = ">=3.7"
@@ -153,9 +144,6 @@ name = "markdown"
 version = "3.3.7"
 requires_python = ">=3.6"
 summary = "Python implementation of Markdown."
-dependencies = [
-    "importlib-metadata>=4.4; python_version < \"3.10\"",
-]
 
 [[package]]
 name = "markupsafe"
@@ -189,7 +177,6 @@ dependencies = [
     "click>=7.0",
     "colorama>=0.4; platform_system == \"Windows\"",
     "ghp-import>=1.0",
-    "importlib-metadata>=4.3; python_version < \"3.10\"",
     "jinja2>=2.11.1",
     "markdown<3.4,>=3.2.1",
     "mergedeep>=1.3.4",
@@ -377,7 +364,6 @@ requires_python = ">=3.7"
 summary = "The little ASGI library that shines."
 dependencies = [
     "anyio<5,>=3.4.0",
-    "typing-extensions>=3.10.0; python_version < \"3.10\"",
 ]
 
 [[package]]
@@ -466,15 +452,9 @@ version = "10.4"
 requires_python = ">=3.7"
 summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
-[[package]]
-name = "zipp"
-version = "3.11.0"
-requires_python = ">=3.7"
-summary = "Backport of pathlib-compatible object wrapper for zip files"
-
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:a33e1b8caeaffce64b87fdda278754ae730aa259e8110205218c34862346de64"
+content_hash = "sha256:d16a99a28e0e005c6ea6af8c87dcc053bad3384379aafad3e3fba730c7571764"
 
 [metadata.files]
 "anyio 3.6.2" = [
@@ -641,10 +621,6 @@ content_hash = "sha256:a33e1b8caeaffce64b87fdda278754ae730aa259e8110205218c34862
 "idna 3.4" = [
     {url = "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
     {url = "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
-]
-"importlib-metadata 5.2.0" = [
-    {url = "https://files.pythonhosted.org/packages/35/07/fd0145f9e57356098fe15415dbb9616fd628373ecf88faab9aae0c988d2c/importlib_metadata-5.2.0-py3-none-any.whl", hash = "sha256:0eafa39ba42bf225fc00e67f701d71f85aead9f878569caf13c3724f704b970f"},
-    {url = "https://files.pythonhosted.org/packages/a6/1d/7a01bc53a248ddb14eb0dca86f089ddf848d7b9485c31d7f840f27acbcfe/importlib_metadata-5.2.0.tar.gz", hash = "sha256:404d48d62bba0b7a77ff9d405efd91501bef2e67ff4ace0bed40a0cf28c3c7cd"},
 ]
 "jinja2 3.1.2" = [
     {url = "https://files.pythonhosted.org/packages/7a/ff/75c28576a1d900e87eb6335b063fab47a8ef3c8b4d88524c4bf78f670cce/Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
@@ -1067,8 +1043,4 @@ content_hash = "sha256:a33e1b8caeaffce64b87fdda278754ae730aa259e8110205218c34862
     {url = "https://files.pythonhosted.org/packages/f8/f0/437187175182beed10246f53ef9793a5f6e087ce71ee25b64fdb12e396e0/websockets-10.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4239b6027e3d66a89446908ff3027d2737afc1a375f8fd3eea630a4842ec9a0c"},
     {url = "https://files.pythonhosted.org/packages/f9/15/ab0e9155700d3037ffe4a146a719f3e68ee025c9d45d6a39b027e928db52/websockets-10.4-cp38-cp38-win32.whl", hash = "sha256:db3c336f9eda2532ec0fd8ea49fef7a8df8f6c804cdf4f39e5c5c0d4a4ad9a7a"},
     {url = "https://files.pythonhosted.org/packages/fd/42/07f31d9f9e142b38cde8d3ea0c8ea1bacf9bc366f2f573eca57086e9f2a6/websockets-10.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:05a7233089f8bd355e8cbe127c2e8ca0b4ea55467861906b80d2ebc7db4d6b72"},
-]
-"zipp 3.11.0" = [
-    {url = "https://files.pythonhosted.org/packages/8e/b3/8b16a007184714f71157b1a71bbe632c5d66dd43bc8152b3c799b13881e1/zipp-3.11.0.tar.gz", hash = "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"},
-    {url = "https://files.pythonhosted.org/packages/d8/20/256eb3f3f437c575fb1a2efdce5e801a5ce3162ea8117da96c43e6ee97d8/zipp-3.11.0-py3-none-any.whl", hash = "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa"},
 ]

--- a/recap/browsers/abstract.py
+++ b/recap/browsers/abstract.py
@@ -24,12 +24,6 @@ class AbstractBrowser(ABC):
         /streaming/kafka/instances/log-cluster/streams/error-logs
     """
 
-    url: str = NotImplemented
-    """
-    The base URL for the infrastructure that this browser is browsing.
-    Something like 'postgresql://user:pass@localhost/my_db`.
-    """
-
     @abstractmethod
     def children(self, path: PurePosixPath) -> List[str]:
         """

--- a/recap/browsers/db.py
+++ b/recap/browsers/db.py
@@ -48,7 +48,6 @@ class DatabaseBrowser(AbstractBrowser):
         self,
         engine: sa.engine.Engine,
     ):
-        self.url = str(engine.url)
         self.engine = engine
 
     def children(self, path: PurePosixPath) -> List[str]:


### PR DESCRIPTION
The `url` variable in AbstractBrowser was never actually used. DatabaseBrowser implemented it, but nothing calls it. I think it's left over from when I was experimenting on the browser API. I'm removing it.