### PR TITLE
Return Pydantic `BaseModel` in analyzers

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -367,6 +367,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringcase"
+version = "1.2.0"
+summary = "String case converter."
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 requires_python = ">=3.7"
@@ -454,7 +459,7 @@ summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:d16a99a28e0e005c6ea6af8c87dcc053bad3384379aafad3e3fba730c7571764"
+content_hash = "sha256:e4c02dfa01959b384c1c7e71d42e1aabb7d06b6f3a079427e20f4039967b6f3b"
 
 [metadata.files]
 "anyio 3.6.2" = [
@@ -866,6 +871,9 @@ content_hash = "sha256:d16a99a28e0e005c6ea6af8c87dcc053bad3384379aafad3e3fba730c
 "starlette 0.22.0" = [
     {url = "https://files.pythonhosted.org/packages/1d/4e/30eda84159d5b3ad7fe663c40c49b16dd17436abe838f10a56c34bee44e8/starlette-0.22.0-py3-none-any.whl", hash = "sha256:b5eda991ad5f0ee5d8ce4c4540202a573bb6691ecd0c712262d0bc85cf8f2c50"},
     {url = "https://files.pythonhosted.org/packages/f7/ff/64bd3362f80e81402f21e0f1ba55f8801cd899ad3f2a1bcc4a94d284c786/starlette-0.22.0.tar.gz", hash = "sha256:b092cbc365bea34dd6840b42861bdabb2f507f8671e642e8272d2442e08ea4ff"},
+]
+"stringcase 1.2.0" = [
+    {url = "https://files.pythonhosted.org/packages/f3/1f/1241aa3d66e8dc1612427b17885f5fcd9c9ee3079fc0d28e9a3aeeb36fa3/stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"},
 ]
 "tomli 2.0.1" = [
     {url = "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "rich>=12.6.0",
     "setuptools>=65.6.3",
     "tomli>=2.0.1",
+    "pydantic>=1.10.4",
+    "stringcase>=1.2.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/recap/analyzers/abstract.py
+++ b/recap/analyzers/abstract.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from pathlib import PurePosixPath
-from typing import Any, Generator
+from pydantic import BaseModel
+from typing import Generator
 
 
 class AbstractAnalyzer(ABC):
@@ -11,7 +12,7 @@ class AbstractAnalyzer(ABC):
     """
 
     @abstractmethod
-    def analyze(self, path: PurePosixPath) -> dict[str, Any]:
+    def analyze(self, path: PurePosixPath) -> BaseModel | None:
         """
         Analyze a path for an infrastructure instance. Only the path is
         specified because the URL for the instance is passed in via the config

--- a/recap/analyzers/db/abstract.py
+++ b/recap/analyzers/db/abstract.py
@@ -3,9 +3,10 @@ import sqlalchemy as sa
 from abc import abstractmethod
 from contextlib import contextmanager
 from pathlib import PurePosixPath
+from pydantic import BaseModel
 from recap.analyzers.abstract import AbstractAnalyzer
 from recap.browsers.db import DatabasePath
-from typing import Any, Generator
+from typing import Generator
 
 
 log = logging.getLogger(__name__)
@@ -18,14 +19,14 @@ class AbstractDatabaseAnalyzer(AbstractAnalyzer):
     ):
         self.engine = engine
 
-    def analyze(self, path: PurePosixPath) -> dict[str, Any]:
+    def analyze(self, path: PurePosixPath) -> BaseModel | None:
         database_path = DatabasePath(path)
         schema = database_path.schema
         table = database_path.table
         if schema and table:
             is_view = path.parts[3] == 'views'
             return self.analyze_table(schema, table, is_view)
-        return {}
+        return None
 
     @abstractmethod
     def analyze_table(
@@ -33,7 +34,7 @@ class AbstractDatabaseAnalyzer(AbstractAnalyzer):
         schema: str,
         table: str,
         is_view: bool = False
-    ) -> dict[str, Any]:
+    ) -> BaseModel | None:
         raise NotImplementedError
 
     @classmethod

--- a/recap/analyzers/db/foreign_key.py
+++ b/recap/analyzers/db/foreign_key.py
@@ -1,10 +1,22 @@
 import logging
 import sqlalchemy as sa
 from .abstract import AbstractDatabaseAnalyzer
-from typing import Any
+from pydantic import BaseModel
+from typing import List
 
 
 log = logging.getLogger(__name__)
+
+
+class ForeignKey(BaseModel):
+    constrained_columns: List[str]
+    referred_columns: List[str]
+    referred_schema: str
+    referred_table: str
+
+
+class ForeignKeys(BaseModel):
+    __root__: dict[str, ForeignKey] = {}
 
 
 class TableForeignKeyAnalyzer(AbstractDatabaseAnalyzer):
@@ -13,6 +25,16 @@ class TableForeignKeyAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str,
         is_view: bool = False
-    ) -> dict[str, Any]:
-        fk_dict = sa.inspect(self.engine).get_foreign_keys(table, schema)
-        return {'foreign_keys': fk_dict} if fk_dict else {}
+    ) -> ForeignKeys | None:
+        results = {}
+        fks = sa.inspect(self.engine).get_foreign_keys(table, schema)
+        for fk_dict in fks or []:
+            results[fk_dict['name']] = ForeignKey(
+                constrained_columns=fk_dict['constrained_columns'],
+                referred_columns=fk_dict['referred_columns'],
+                referred_schema=fk_dict['referred_schema'],
+                referred_table=fk_dict['referred_table'],
+            )
+        if results:
+            return ForeignKeys.parse_obj(results)
+        return None

--- a/recap/analyzers/db/location.py
+++ b/recap/analyzers/db/location.py
@@ -3,11 +3,22 @@ import sqlalchemy as sa
 from .abstract import AbstractDatabaseAnalyzer
 from contextlib import contextmanager
 from pathlib import PurePosixPath
+from pydantic import BaseModel, Field
 from recap.browsers.db import DatabaseBrowser
 from typing import Any, Generator
 
 
 log = logging.getLogger(__name__)
+
+
+class Location(BaseModel):
+    database: str
+    instance: str
+    # Schema is a reserved word in BaseModel.
+    schema_: str = Field(alias='schema')
+    # TODO Should validate either table or view is set and show in JSON schema.
+    table: str | None = None
+    view: str | None = None
 
 
 class TableLocationAnalyzer(AbstractDatabaseAnalyzer):
@@ -26,18 +37,17 @@ class TableLocationAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str,
         is_view: bool = False
-    ) -> dict[str, Any]:
+    ) -> Location | None:
         if schema and table:
             table_or_view = 'view' if is_view else 'table'
-            return {
-                'location': {
-                    'database': self.database,
-                    'instance': self.instance,
-                    'schema': schema,
-                    table_or_view: table,
-                }
+            kwargs = {
+                'database': self.database,
+                'instance': self.instance,
+                'schema': schema,
+                table_or_view: table,
             }
-        return {}
+            return Location.parse_obj(kwargs)
+        return None
 
     @classmethod
     @contextmanager

--- a/recap/analyzers/db/view_definition.py
+++ b/recap/analyzers/db/view_definition.py
@@ -1,10 +1,14 @@
 import logging
 import sqlalchemy as sa
 from .abstract import AbstractDatabaseAnalyzer
-from typing import Any
+from pydantic import BaseModel
 
 
 log = logging.getLogger(__name__)
+
+
+class ViewDefinition(BaseModel):
+    __root__: str | None = None
 
 
 class TableViewDefinitionAnalyzer(AbstractDatabaseAnalyzer):
@@ -13,12 +17,15 @@ class TableViewDefinitionAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str,
         is_view: bool = False
-    ) -> dict[str, Any]:
-        if not is_view:
-            return {}
-        # TODO sqlalchemy-bigquery doesn't work right with this API
-        # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/539
-        if self.engine.dialect.name == 'bigquery':
-            table = f"{schema}.{table}"
-        def_dict = sa.inspect(self.engine).get_view_definition(table, schema)
-        return {'view_definition': def_dict} if def_dict else {}
+    ) -> ViewDefinition | None:
+        if is_view:
+            # TODO sqlalchemy-bigquery doesn't work right with this API
+            # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/539
+            if self.engine.dialect.name == 'bigquery':
+                table = f"{schema}.{table}"
+            def_dict = sa \
+                .inspect(self.engine) \
+                .get_view_definition(table, schema)
+            if def_dict:
+                return ViewDefinition.parse_obj(def_dict)
+        return None


### PR DESCRIPTION
Analyzers used to return `dict[str, Any]`; they now return `BaseModel | None`.

Thie `dict[str, Any]` return type never sat right with me. Analyzers can be used on their own in Python, so having a strong return type felt ergonomic. Strongly typed return types also make it possible to generate JSON schemas for the API--something I've been exploring.

I went back and forth between Python's `dataclasses.dataclass` and Pydantic's `BaseModel`. I opted for `BaseModel` for a number of reasons:

1. It serializes to JSON with `json()`, which is nice.
2. It has support for JSON schemas.
3. It has `__root__`, which allows metadata to be `Any`, rather than just a `dict`/`List`/`Tuple`.
4. Pydantic works nicely with FastAP and RichI
5. There were some other reasons, which I forget now. :P

I opted not to have an `AbstractMetadataModel` because I want to give Analyzers the flexibility to return any type using `__root__`. Forcing fields in an `AbstractMetadataModel` (for example, forcing a `name` field) prevents this this.

This change means that analyzers no longer return the name of their metadata in the `dict[str, Any]` (the `str` was the metadata name for the `Any` metadata). Metadata names are now auto-derived using the `stringcase` module. `stringcase` is super simple (it just depends on `regex`) and looks pretty stable, so it seems like a safe dependency to add.