### PR TITLE
Introduce `CatalogPath` model in `AbstractBrowser`

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -572,7 +572,7 @@ summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:8ac6561a652c7bb1cb68660fb1466a2e48db0520e1060ada10cff97a8833dce0"
+content_hash = "sha256:40c7a0a4ebbcbd387a87e0452d03dff1a35d0274572516e6a285501f5ff3357a"
 
 [metadata.files]
 "anyio 3.6.2" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "tomli>=2.0.1",
     "pydantic>=1.10.4",
     "stringcase>=1.2.0",
+    "starlette>=0.22.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/recap/analyzers/db/abstract.py
+++ b/recap/analyzers/db/abstract.py
@@ -20,11 +20,10 @@ class AbstractDatabaseAnalyzer(AbstractAnalyzer):
         self.engine = engine
 
     def analyze(self, path: PurePosixPath) -> BaseModel | None:
-        database_path = DatabasePath(path)
-        schema = database_path.schema
-        table = database_path.table
-        if schema and table:
-            is_view = path.parts[3] == 'views'
+        if len(path.parts) > 8:
+            schema = path.parts[6]
+            table = path.parts[8]
+            is_view = path.parts[7] == 'views'
             return self.analyze_table(schema, table, is_view)
         return None
 

--- a/recap/analyzers/db/location.py
+++ b/recap/analyzers/db/location.py
@@ -55,5 +55,5 @@ class TableLocationAnalyzer(AbstractDatabaseAnalyzer):
         assert 'url' in config, \
             f"Config for {cls.__name__} is missing `url` config."
         engine = sa.create_engine(config['url'])
-        root = DatabaseBrowser.root(**config)
-        yield TableLocationAnalyzer(root, engine)
+        with DatabaseBrowser.open(**config) as browser:
+            yield TableLocationAnalyzer(browser.instance.path(), engine)

--- a/recap/browsers/abstract.py
+++ b/recap/browsers/abstract.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from pathlib import PurePosixPath
+from recap.paths import CatalogPath
 from typing import Generator
 
 
@@ -12,37 +13,41 @@ class AbstractBrowser(ABC):
     Browsers map infrastructure objects into a standard directory format. A
     different browser is used for each type of infrastructure.
 
-    A KafkaBrowser might list directories like this:
+    A DatabaseBrowser might list directories like this:
 
         /
-        /streaming
-        /streaming/kafka
-        /streaming/kafka/instances
-        /streaming/kafka/instances/log-cluster
-        /streaming/kafka/instances/log-cluster/streams
-        /streaming/kafka/instances/log-cluster/streams/access-logs
-        /streaming/kafka/instances/log-cluster/streams/error-logs
+        /databases
+        /databases/postgresql
+        /databases/postgresql/instances
+        /databases/postgresql/instances/localhost
+        /databases/postgresql/instances/localhost/schemas
+        /databases/postgresql/instances/localhost/schemas/public
+        /databases/postgresql/instances/localhost/schemas/public/tables
+        /databases/postgresql/instances/localhost/schemas/public/tables/groups
+        /databases/postgresql/instances/localhost/schemas/public/tables/users
     """
 
     @abstractmethod
-    def children(self, path: PurePosixPath) -> list[str]:
+    def children(self, path: PurePosixPath) -> list[CatalogPath] | None:
         """
         Given a path, returns its children. Using the example above,
-        path="/streaming/kafka/instances/log-cluster/streams" would return:
+        path=/databases/postgresql/instances/localhost/schemas/public/tables
+        would return:
 
-            ["access-logs", "error-logs"]
-        """
-
-        raise NotImplementedError
-
-    @staticmethod
-    @abstractmethod
-    def root(**config) -> PurePosixPath:
-        """
-        Returns the root directory for this browser. Using the example above,
-        root() would return:
-
-            /streaming/kafka/instances/log-cluster
+            [
+                TablePath(
+                    scheme='postgresl',
+                    instance='localhost',
+                    schema='public',
+                    table='groups',
+                ),
+                TablePath(
+                    scheme='postgresl',
+                    instance='localhost',
+                    schema='public',
+                    table='users',
+                ),
+            ]
         """
 
         raise NotImplementedError

--- a/recap/commands/crawl.py
+++ b/recap/commands/crawl.py
@@ -67,7 +67,7 @@ def crawl(
                     with (Progress(spinner, text) as progress):
                         # Set up the spinner description.
                         task_id = progress.add_task(
-                            description=f"Crawling {crawler.root} ...",
+                            description=f"Crawling {url} ...",
                             total=1,
                         )
 

--- a/recap/paths.py
+++ b/recap/paths.py
@@ -1,0 +1,92 @@
+from pathlib import PurePosixPath
+from pydantic import BaseModel
+from typing import ClassVar, Optional, Type
+from starlette.routing import compile_path
+
+
+class CatalogPath(BaseModel):
+    """
+    Represents a path in the data catalog.
+    """
+
+    templates: ClassVar[list[PurePosixPath]]
+    """
+    A list of templated paths that represent the various locations of this path
+    type. The template format uses Starlette's simplified URI style. For
+    example:
+
+        /databases/{scheme}/instances/{instance}/schemas/{schema}
+    """
+
+    def name(self) -> str:
+        return self.path().parts[-1]
+
+    def path(self) -> PurePosixPath:
+        """
+        Find a template format that has parameters compatible with this
+        instance. If one is found, fill it in with this instance's
+        attributes and return it. For example, a template:
+
+            /databases/{scheme}/instances/{instance}/schemas/{schema}
+
+        Would return:
+
+            /databases/postgresql/instances/localhost/schemas/public
+
+        If the instance had:
+
+            SomeCatalogPath(
+                scheme='postgresql',
+                instance='localhost',
+                schema='public']
+            )
+        """
+        for template in self.__class__.templates:
+            try:
+                return PurePosixPath(
+                    # TODO Should use Starlette formatting so typed variables
+                    # (e.g. {path:path} or {name:str}) are handled properly.
+                    str(template).format(**self.dict(
+                        by_alias=True,
+                        exclude_none=True,
+                        exclude_unset=True,
+                    ))
+                )
+            except KeyError:
+                pass
+        raise ValueError("No template is compatible with model variables")
+
+    @classmethod
+    def from_path(cls, path: PurePosixPath) -> Optional['CatalogPath']:
+        """
+        Construct this model from a PurePosixPath the path matches one of this
+        model's templates.
+        """
+        path_str = str(path)
+        for template in cls.templates:
+            template_regex, _, _ = compile_path(str(template))
+            if match := template_regex.match(path_str):
+                return cls(**match.groupdict())
+        return None
+
+
+class RootPath(CatalogPath):
+    """
+    Canonical root path for the catalog.
+    """
+    templates = [PurePosixPath('/')]
+
+
+def create_catalog_path(
+    path: PurePosixPath,
+    *types: Type[CatalogPath],
+) -> CatalogPath | None:
+    """
+    Given a collection of CatalogPath types, find one that has a template that
+    matches the provided path. If a matching path is found, instantiate the
+    CatalogPath type and return it.
+    """
+    for type_ in types + (RootPath, ):
+        if catalog_path := type_.from_path(path):
+            return catalog_path
+    return None


### PR DESCRIPTION
I'm moving away from unstructured `PurePosixPath` catalog directories. I like this change for two reasons:

1. Analyzers will be able to take kwargs instead of a PurePosixPath in `analyze()`. This will make analyzers more ergonomic for end users to call in Python.
2. `recap.routers.metadata` will be able to inspect all browsers to get the return types for `children`. This will allow the metadata `APIRouter` to expose strongly typed Pydantic models for all of the browser paths.

This change adds a `CatalogPath` Pydantic model. The `CatalogPath` defines template paths that represent a particular catalog path. The template paths use Starlette's simplified URI style [1]. For example:

    /databases/{database}/instances/{instance}/schemas/{schema}/tables/{table}

Subtypes of `CatalogPath` can define the attribute they require. Continuing the above example:

```
class TablePath(CatalogPath):
    scheme: str
    instance: str
    schema_: str = Field(alias='schema')
    table: str
    templates = [PurePosixPath(
        '/databases/{scheme}/instances/{instance}/schemas/{schema}/tables/{table}')]
```

Shortly, I'd like to move from `PurePosixPath` to `str` for APIs, just to make it easier on end-users (even though it's less typesafe).

[1] https://www.starlette.io/routing/#path-parameters