### PR TITLE
Pass `**kwargs` to `AbstractAnalyzer.analyze()` instead of `PurePosix…

### DIFF
--- a/recap/analyzers/abstract.py
+++ b/recap/analyzers/abstract.py
@@ -18,14 +18,15 @@ class AbstractAnalyzer(ABC):
     """
 
     @abstractmethod
-    def analyze(self, path: PurePosixPath) -> BaseMetadataModel | None:
+    def analyze(self, **kwargs) -> BaseMetadataModel | None:
         """
         Analyze a path for an infrastructure instance. Only the path is
         specified because the URL for the instance is passed in via the config
         in `open()`.
 
-        :returns: Metadata dictionary of the format {"metadata_type": Any}.
-            This data gets serialized as JSON in the catalog.
+        :returns: BaseMetadataModel Pydantic BaseModel, which represents
+            discovered metadata. This data gets serialized as JSON in the
+            catalog.
         """
 
         raise NotImplementedError

--- a/recap/analyzers/db/abstract.py
+++ b/recap/analyzers/db/abstract.py
@@ -1,11 +1,7 @@
 import logging
 import sqlalchemy as sa
-from abc import abstractmethod
 from contextlib import contextmanager
-from pathlib import PurePosixPath
-from pydantic import BaseModel
 from recap.analyzers.abstract import AbstractAnalyzer
-from recap.browsers.db import DatabasePath
 from typing import Generator
 
 
@@ -19,22 +15,10 @@ class AbstractDatabaseAnalyzer(AbstractAnalyzer):
     ):
         self.engine = engine
 
-    def analyze(self, path: PurePosixPath) -> BaseModel | None:
-        if len(path.parts) > 8:
-            schema = path.parts[6]
-            table = path.parts[8]
-            is_view = path.parts[7] == 'views'
-            return self.analyze_table(schema, table, is_view)
-        return None
-
-    @abstractmethod
-    def analyze_table(
-        self,
-        schema: str,
-        table: str,
-        is_view: bool = False
-    ) -> BaseModel | None:
-        raise NotImplementedError
+    def _table_or_view(self, table: str | None, view: str | None) -> str:
+        table_or_view = table or view
+        assert table_or_view, 'Either table or view must be set.'
+        return table_or_view
 
     @classmethod
     @contextmanager

--- a/recap/analyzers/db/access.py
+++ b/recap/analyzers/db/access.py
@@ -18,12 +18,14 @@ class Access(BaseMetadataModel):
 
 
 class TableAccessAnalyzer(AbstractDatabaseAnalyzer):
-    def analyze_table(
+    def analyze(
         self,
         schema: str,
-        table: str,
-        is_view: bool = False
+        table: str | None = None,
+        view: str | None = None,
+        **_,
     ) -> Access | None:
+        table = self._table_or_view(table, view)
         with self.engine.connect() as conn:
             results = {}
             try:

--- a/recap/analyzers/db/column.py
+++ b/recap/analyzers/db/column.py
@@ -21,12 +21,14 @@ class Columns(BaseMetadataModel):
 
 
 class TableColumnAnalyzer(AbstractDatabaseAnalyzer):
-    def analyze_table(
+    def analyze(
         self,
         schema: str,
-        table: str,
-        is_view: bool = False
+        table: str | None = None,
+        view: str | None = None,
+        **_,
     ) -> Columns | None:
+        table = self._table_or_view(table, view)
         results = {}
         columns = sa.inspect(self.engine).get_columns(table, schema)
         for column in columns:

--- a/recap/analyzers/db/comment.py
+++ b/recap/analyzers/db/comment.py
@@ -12,12 +12,14 @@ class Comment(BaseMetadataModel):
 
 
 class TableCommentAnalyzer(AbstractDatabaseAnalyzer):
-    def analyze_table(
+    def analyze(
         self,
         schema: str,
-        table: str,
-        is_view: bool = False
+        table: str | None = None,
+        view: str | None = None,
+        **_,
     ) -> Comment | None:
+        table = self._table_or_view(table, view)
         try:
             comment = sa.inspect(self.engine).get_table_comment(table, schema)
             comment_text = comment.get('text')

--- a/recap/analyzers/db/foreign_key.py
+++ b/recap/analyzers/db/foreign_key.py
@@ -19,12 +19,14 @@ class ForeignKeys(BaseMetadataModel):
 
 
 class TableForeignKeyAnalyzer(AbstractDatabaseAnalyzer):
-    def analyze_table(
+    def analyze(
         self,
         schema: str,
-        table: str,
-        is_view: bool = False
+        table: str | None = None,
+        view: str | None = None,
+        **_,
     ) -> ForeignKeys | None:
+        table = self._table_or_view(table, view)
         results = {}
         fks = sa.inspect(self.engine).get_foreign_keys(table, schema)
         for fk_dict in fks or []:

--- a/recap/analyzers/db/index.py
+++ b/recap/analyzers/db/index.py
@@ -17,12 +17,14 @@ class Indexes(BaseMetadataModel):
 
 
 class TableIndexAnalyzer(AbstractDatabaseAnalyzer):
-    def analyze_table(
+    def analyze(
         self,
         schema: str,
-        table: str,
-        is_view: bool = False
+        table: str | None = None,
+        view: str | None = None,
+        **_,
     ) -> Indexes | None:
+        table = self._table_or_view(table, view)
         indexes = {}
         index_dicts = sa.inspect(self.engine).get_indexes(table, schema)
         for index_dict in index_dicts:

--- a/recap/analyzers/db/location.py
+++ b/recap/analyzers/db/location.py
@@ -32,21 +32,23 @@ class TableLocationAnalyzer(AbstractDatabaseAnalyzer):
         self.database = root.parts[2]
         self.instance = root.parts[4]
 
-    def analyze_table(
+    def analyze(
         self,
         schema: str,
-        table: str,
-        is_view: bool = False
+        table: str | None = None,
+        view: str | None = None,
+        **_,
     ) -> Location | None:
+        table = self._table_or_view(table, view)
         if schema and table:
-            table_or_view = 'view' if is_view else 'table'
-            kwargs = {
+            table_or_view = 'view' if view else 'table'
+            location_dict = {
                 'database': self.database,
                 'instance': self.instance,
                 'schema': schema,
                 table_or_view: table,
             }
-            return Location.parse_obj(kwargs)
+            return Location.parse_obj(location_dict)
         return None
 
     @classmethod

--- a/recap/analyzers/db/primary_key.py
+++ b/recap/analyzers/db/primary_key.py
@@ -13,12 +13,14 @@ class PrimaryKey(BaseMetadataModel):
 
 
 class TablePrimaryKeyAnalyzer(AbstractDatabaseAnalyzer):
-    def analyze_table(
+    def analyze(
         self,
         schema: str,
-        table: str,
-        is_view: bool = False
+        table: str | None = None,
+        view: str | None = None,
+        **_,
     ) -> PrimaryKey | None:
+        table = self._table_or_view(table, view)
         pk_dict = sa.inspect(self.engine).get_pk_constraint(table, schema)
         if pk_dict and pk_dict.get('name'):
             return PrimaryKey.parse_obj(pk_dict)

--- a/recap/analyzers/db/profile.py
+++ b/recap/analyzers/db/profile.py
@@ -59,17 +59,19 @@ class Profile(BaseMetadataModel):
 
 
 class TableProfileAnalyzer(AbstractDatabaseAnalyzer):
-    def analyze_table(
+    def analyze(
         self,
         schema: str,
-        table: str,
-        is_view: bool = False
+        table: str | None = None,
+        view: str | None = None,
+        **_,
     ) -> Profile | None:
+        table = self._table_or_view(table, view)
         column_analyzer = TableColumnAnalyzer(self.engine)
         # TODO This is very proof-of-concept...
         # TODO ZOMG SQL injection attacks all over!
         # TODO Is db.Table().select the right way to paramaterize tables?
-        columns = column_analyzer.analyze_table(schema, table) or Columns()
+        columns = column_analyzer.analyze(schema, table) or Columns()
         sql_col_queries = ''
         numeric_types = [
             'BIGINT', 'FLOAT', 'INT', 'INTEGER', 'NUMERIC', 'REAL', 'SMALLINT'

--- a/recap/analyzers/db/view_definition.py
+++ b/recap/analyzers/db/view_definition.py
@@ -12,20 +12,19 @@ class ViewDefinition(BaseMetadataModel):
 
 
 class TableViewDefinitionAnalyzer(AbstractDatabaseAnalyzer):
-    def analyze_table(
+    def analyze(
         self,
         schema: str,
-        table: str,
-        is_view: bool = False
+        view: str,
+        **_,
     ) -> ViewDefinition | None:
-        if is_view:
-            # TODO sqlalchemy-bigquery doesn't work right with this API
-            # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/539
-            if self.engine.dialect.name == 'bigquery':
-                table = f"{schema}.{table}"
-            def_dict = sa \
-                .inspect(self.engine) \
-                .get_view_definition(table, schema)
-            if def_dict:
-                return ViewDefinition.parse_obj(def_dict)
+        # TODO sqlalchemy-bigquery doesn't work right with this API
+        # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/539
+        if self.engine.dialect.name == 'bigquery':
+            view = f"{schema}.{view}"
+        def_dict = sa \
+            .inspect(self.engine) \
+            .get_view_definition(view, schema)
+        if def_dict:
+            return ViewDefinition.parse_obj(def_dict)
         return None

--- a/recap/paths.py
+++ b/recap/paths.py
@@ -56,6 +56,9 @@ class CatalogPath(BaseModel):
                 pass
         raise ValueError("No template is compatible with model variables")
 
+    def __str__(self) -> str:
+        return str(self.path())
+
     @classmethod
     def from_path(cls, path: PurePosixPath) -> Optional['CatalogPath']:
         """


### PR DESCRIPTION
…Path`

It always bothered me that `AbstractAnalyzer.analyze()` took a `PurePosixPath` as its parameter. This never felt ergonomic for developers that want to call `analyze()` using Python.

Now that `CatalogPath` exists, the crawler can pass `**path.dict()` to the analyzer, and the analyzer can use `**kwargs`. For implementations, they can name typed parameters, so `analyze()` looks like a normal-ish method.

I still had to include `**_` as the trailing path because sometimes the `analyze()` method doesn't use all of the key word arguments passed in from the crawler. I think I can fix this, though, with some method inspection and Pydantic argument filtering. I'll save that for a future commit.