### PR TITLE
Eliminate `**_` requirement for `analyzer.analyze()` methods

### DIFF
--- a/recap/analyzers/db/access.py
+++ b/recap/analyzers/db/access.py
@@ -23,7 +23,6 @@ class TableAccessAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str | None = None,
         view: str | None = None,
-        **_,
     ) -> Access | None:
         table = self._table_or_view(table, view)
         with self.engine.connect() as conn:

--- a/recap/analyzers/db/column.py
+++ b/recap/analyzers/db/column.py
@@ -26,7 +26,6 @@ class TableColumnAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str | None = None,
         view: str | None = None,
-        **_,
     ) -> Columns | None:
         table = self._table_or_view(table, view)
         results = {}

--- a/recap/analyzers/db/comment.py
+++ b/recap/analyzers/db/comment.py
@@ -17,7 +17,6 @@ class TableCommentAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str | None = None,
         view: str | None = None,
-        **_,
     ) -> Comment | None:
         table = self._table_or_view(table, view)
         try:

--- a/recap/analyzers/db/foreign_key.py
+++ b/recap/analyzers/db/foreign_key.py
@@ -24,7 +24,6 @@ class TableForeignKeyAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str | None = None,
         view: str | None = None,
-        **_,
     ) -> ForeignKeys | None:
         table = self._table_or_view(table, view)
         results = {}

--- a/recap/analyzers/db/index.py
+++ b/recap/analyzers/db/index.py
@@ -22,7 +22,6 @@ class TableIndexAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str | None = None,
         view: str | None = None,
-        **_,
     ) -> Indexes | None:
         table = self._table_or_view(table, view)
         indexes = {}

--- a/recap/analyzers/db/location.py
+++ b/recap/analyzers/db/location.py
@@ -37,7 +37,6 @@ class TableLocationAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str | None = None,
         view: str | None = None,
-        **_,
     ) -> Location | None:
         table = self._table_or_view(table, view)
         if schema and table:

--- a/recap/analyzers/db/primary_key.py
+++ b/recap/analyzers/db/primary_key.py
@@ -18,7 +18,6 @@ class TablePrimaryKeyAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str | None = None,
         view: str | None = None,
-        **_,
     ) -> PrimaryKey | None:
         table = self._table_or_view(table, view)
         pk_dict = sa.inspect(self.engine).get_pk_constraint(table, schema)

--- a/recap/analyzers/db/profile.py
+++ b/recap/analyzers/db/profile.py
@@ -64,7 +64,6 @@ class TableProfileAnalyzer(AbstractDatabaseAnalyzer):
         schema: str,
         table: str | None = None,
         view: str | None = None,
-        **_,
     ) -> Profile | None:
         table = self._table_or_view(table, view)
         column_analyzer = TableColumnAnalyzer(self.engine)

--- a/recap/analyzers/db/view_definition.py
+++ b/recap/analyzers/db/view_definition.py
@@ -16,7 +16,6 @@ class TableViewDefinitionAnalyzer(AbstractDatabaseAnalyzer):
         self,
         schema: str,
         view: str,
-        **_,
     ) -> ViewDefinition | None:
         # TODO sqlalchemy-bigquery doesn't work right with this API
         # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/539

--- a/recap/crawler.py
+++ b/recap/crawler.py
@@ -1,4 +1,5 @@
 import fnmatch
+from inspect import signature
 import logging
 from .plugins import load_analyzer_plugins, load_browser_plugins
 from contextlib import contextmanager, ExitStack
@@ -107,7 +108,8 @@ class Crawler:
                 type(analyzer).__name__,
             )
             try: # EAFP
-                if metadata := analyzer.analyze(**path.dict(by_alias=True)):
+                analyzer_params = self._params_for_analyzer(path, analyzer)
+                if metadata := analyzer.analyze(**analyzer_params):
                     metadata_dict = metadata.dict(
                         by_alias=True,
                         exclude_none=True,
@@ -124,10 +126,30 @@ class Crawler:
                 log.debug(
                     'Unable to process path with analyzer path=%s analyzer=%s',
                     path,
-                    analyzer,
+                    analyzer.__class__.__name__,
                     exc_info=e,
                 )
         return results
+
+    def _params_for_analyzer(
+        self,
+        path: CatalogPath,
+        analyzer: AbstractAnalyzer,
+    ) -> dict[str, Any]:
+        """
+        Figure out which typed arguments `analyzer.analyze()` supports, and
+        return a dictionary with only those keys. If the analyzer contains an
+        argument not in `path`, then the key remains unset in the return
+        dictionary.
+
+        This method keeps analyzers from having to include a `**kwargs` or
+        `**_` at the end of their `analyze()` method.
+        """
+        # TODO The dictionary should be unfiltered if params has a ** argument.
+        path_dict = path.dict(by_alias=True)
+        params = list(signature(analyzer.analyze).parameters)
+        filtered_dict = {p: path_dict[p] for p in params if p in path_dict}
+        return filtered_dict
 
     def _write_metadata(
         self,


### PR DESCRIPTION
Prior to this commit, `analyze()` methods had to include a `**` argument at the end to handle unused arguments that were passed in from the crawler. This felt clunky. I added a convenience method in the crawler that filters out arguments that don't match the analyzer's `analyze()` method signature.

The implementation is a bit brittle. It doesn't, for example, handle `analyze(..., **kwargs)`. It should just pass the full path dict in that case. It also doesn't allow `analyze()` to take in the path model if it wants (like `analyze(model=SomeCatalogPath)`). This is all future work.