### PR TITLE
Update `analyze()` to take a `CatalogPath`

### DIFF
--- a/recap/analyzers/abstract.py
+++ b/recap/analyzers/abstract.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from pathlib import PurePosixPath
 from pydantic import BaseModel
+from recap.paths import CatalogPath
 from stringcase import snakecase
 from typing import Generator
 
@@ -18,7 +18,7 @@ class AbstractAnalyzer(ABC):
     """
 
     @abstractmethod
-    def analyze(self, **kwargs) -> BaseMetadataModel | None:
+    def analyze(self, path: CatalogPath) -> BaseMetadataModel | None:
         """
         Analyze a path for an infrastructure instance. Only the path is
         specified because the URL for the instance is passed in via the config

--- a/recap/analyzers/db/abstract.py
+++ b/recap/analyzers/db/abstract.py
@@ -15,11 +15,6 @@ class AbstractDatabaseAnalyzer(AbstractAnalyzer):
     ):
         self.engine = engine
 
-    def _table_or_view(self, table: str | None, view: str | None) -> str:
-        table_or_view = table or view
-        assert table_or_view, 'Either table or view must be set.'
-        return table_or_view
-
     @classmethod
     @contextmanager
     def open(cls, **config) -> Generator['AbstractDatabaseAnalyzer', None, None]:

--- a/recap/analyzers/db/foreign_key.py
+++ b/recap/analyzers/db/foreign_key.py
@@ -2,6 +2,7 @@ import logging
 import sqlalchemy as sa
 from .abstract import AbstractDatabaseAnalyzer
 from recap.analyzers.abstract import BaseMetadataModel
+from recap.browsers.db import TablePath, ViewPath
 
 
 log = logging.getLogger(__name__)
@@ -21,13 +22,11 @@ class ForeignKeys(BaseMetadataModel):
 class TableForeignKeyAnalyzer(AbstractDatabaseAnalyzer):
     def analyze(
         self,
-        schema: str,
-        table: str | None = None,
-        view: str | None = None,
+        path: TablePath | ViewPath,
     ) -> ForeignKeys | None:
-        table = self._table_or_view(table, view)
+        table = path.table if isinstance(path, TablePath) else path.view
         results = {}
-        fks = sa.inspect(self.engine).get_foreign_keys(table, schema)
+        fks = sa.inspect(self.engine).get_foreign_keys(table, path.schema_)
         for fk_dict in fks or []:
             results[fk_dict['name']] = ForeignKey(
                 constrained_columns=fk_dict['constrained_columns'],

--- a/recap/analyzers/db/index.py
+++ b/recap/analyzers/db/index.py
@@ -2,6 +2,7 @@ import logging
 import sqlalchemy as sa
 from .abstract import AbstractDatabaseAnalyzer
 from recap.analyzers.abstract import BaseMetadataModel
+from recap.browsers.db import TablePath, ViewPath
 
 
 log = logging.getLogger(__name__)
@@ -19,13 +20,11 @@ class Indexes(BaseMetadataModel):
 class TableIndexAnalyzer(AbstractDatabaseAnalyzer):
     def analyze(
         self,
-        schema: str,
-        table: str | None = None,
-        view: str | None = None,
+        path: TablePath | ViewPath,
     ) -> Indexes | None:
-        table = self._table_or_view(table, view)
+        table = path.table if isinstance(path, TablePath) else path.view
         indexes = {}
-        index_dicts = sa.inspect(self.engine).get_indexes(table, schema)
+        index_dicts = sa.inspect(self.engine).get_indexes(table, path.schema_)
         for index_dict in index_dicts:
             indexes[index_dict['name']] = {
                 'columns': index_dict.get('column_names', []),

--- a/recap/analyzers/db/primary_key.py
+++ b/recap/analyzers/db/primary_key.py
@@ -2,6 +2,7 @@ import logging
 import sqlalchemy as sa
 from .abstract import AbstractDatabaseAnalyzer
 from recap.analyzers.abstract import BaseMetadataModel
+from recap.browsers.db import TablePath, ViewPath
 
 
 log = logging.getLogger(__name__)
@@ -15,12 +16,13 @@ class PrimaryKey(BaseMetadataModel):
 class TablePrimaryKeyAnalyzer(AbstractDatabaseAnalyzer):
     def analyze(
         self,
-        schema: str,
-        table: str | None = None,
-        view: str | None = None,
+        path: TablePath | ViewPath,
     ) -> PrimaryKey | None:
-        table = self._table_or_view(table, view)
-        pk_dict = sa.inspect(self.engine).get_pk_constraint(table, schema)
+        table = path.table if isinstance(path, TablePath) else path.view
+        pk_dict = sa.inspect(self.engine).get_pk_constraint(
+            table,
+            path.schema_,
+        )
         if pk_dict and pk_dict.get('name'):
             return PrimaryKey.parse_obj(pk_dict)
         return None

--- a/recap/analyzers/db/view_definition.py
+++ b/recap/analyzers/db/view_definition.py
@@ -2,6 +2,7 @@ import logging
 import sqlalchemy as sa
 from .abstract import AbstractDatabaseAnalyzer
 from recap.analyzers.abstract import BaseMetadataModel
+from recap.browsers.db import ViewPath
 
 
 log = logging.getLogger(__name__)
@@ -14,16 +15,16 @@ class ViewDefinition(BaseMetadataModel):
 class TableViewDefinitionAnalyzer(AbstractDatabaseAnalyzer):
     def analyze(
         self,
-        schema: str,
-        view: str,
+        path: ViewPath,
     ) -> ViewDefinition | None:
         # TODO sqlalchemy-bigquery doesn't work right with this API
         # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/539
+        view = path.view
         if self.engine.dialect.name == 'bigquery':
-            view = f"{schema}.{view}"
+            view = f"{path.schema_}.{path.view}"
         def_dict = sa \
             .inspect(self.engine) \
-            .get_view_definition(view, schema)
+            .get_view_definition(view, path.schema_)
         if def_dict:
             return ViewDefinition.parse_obj(def_dict)
         return None

--- a/recap/crawler.py
+++ b/recap/crawler.py
@@ -108,8 +108,7 @@ class Crawler:
                 type(analyzer).__name__,
             )
             try: # EAFP
-                analyzer_params = self._params_for_analyzer(path, analyzer)
-                if metadata := analyzer.analyze(**analyzer_params):
+                if metadata := analyzer.analyze(path):
                     metadata_dict = metadata.dict(
                         by_alias=True,
                         exclude_none=True,
@@ -130,26 +129,6 @@ class Crawler:
                     exc_info=e,
                 )
         return results
-
-    def _params_for_analyzer(
-        self,
-        path: CatalogPath,
-        analyzer: AbstractAnalyzer,
-    ) -> dict[str, Any]:
-        """
-        Figure out which typed arguments `analyzer.analyze()` supports, and
-        return a dictionary with only those keys. If the analyzer contains an
-        argument not in `path`, then the key remains unset in the return
-        dictionary.
-
-        This method keeps analyzers from having to include a `**kwargs` or
-        `**_` at the end of their `analyze()` method.
-        """
-        # TODO The dictionary should be unfiltered if params has a ** argument.
-        path_dict = path.dict(by_alias=True)
-        params = list(signature(analyzer.analyze).parameters)
-        filtered_dict = {p: path_dict[p] for p in params if p in path_dict}
-        return filtered_dict
 
     def _write_metadata(
         self,


### PR DESCRIPTION
After going down the rabbit hole with kwargs for `analyze()`, I've decided it's just too much magic for the value it adds. I'm making `analyze()` take a `CatalogPath` now; a slight twist on the original implementation, which took a `PurePosixPath`.

This implementation is less natural for humans calling they API--they must now create a CatalogPath. But it's more convenient for the crawler and REST API, and is far more typesafe. I'm going with it for now.