### PR TITLE
Remove `open()` from `AbstractAnalyzer`

### DIFF
--- a/recap/analyzers/abstract.py
+++ b/recap/analyzers/abstract.py
@@ -30,13 +30,3 @@ class AbstractAnalyzer(ABC):
         """
 
         raise NotImplementedError
-
-    @staticmethod
-    @contextmanager
-    @abstractmethod
-    def open(**config) -> Generator['AbstractAnalyzer', None, None]:
-        """
-        Creates and returns an analyzer using the supplied config.
-        """
-
-        raise NotImplementedError

--- a/recap/analyzers/db/abstract.py
+++ b/recap/analyzers/db/abstract.py
@@ -12,13 +12,6 @@ class AbstractDatabaseAnalyzer(AbstractAnalyzer):
     def __init__(
         self,
         engine: sa.engine.Engine,
+        **_,
     ):
         self.engine = engine
-
-    @classmethod
-    @contextmanager
-    def open(cls, **config) -> Generator['AbstractDatabaseAnalyzer', None, None]:
-        assert 'url' in config, \
-            f"Config for {cls.__name__} is missing `url` config."
-        engine = sa.create_engine(config['url'])
-        yield cls(engine)


### PR DESCRIPTION
I'm moving away from the clunky `open()` methods. I'm starting with `AbstractAnalyzer`. I've replaced `open()` with just an `__init__()` method.

The crawler passes all browser attributes to the `AbstractAnalyzer.__init__()` method as kwargs.

If an analyzer wishes to open its own connections, rather than reuse whatever the browser has, it can implement `AbstractContextManager`. The crawler will add it to the `ExitStack`.