### PR TITLE
Simplify `CatalogPath`

### DIFF
--- a/recap/browsers/db.py
+++ b/recap/browsers/db.py
@@ -13,50 +13,50 @@ log = logging.getLogger(__name__)
 
 
 class DatabasesPath(CatalogPath):
-    templates = [PurePosixPath('/databases')]
+    template = '/databases'
 
 
 class DatabasePath(CatalogPath):
     scheme: str
-    templates = [PurePosixPath('/databases/{scheme}')]
+    template = '/databases/{scheme}'
 
 
 class InstancesPath(CatalogPath):
     scheme: str
-    templates = [PurePosixPath('/databases/{scheme}/instances')]
+    template = '/databases/{scheme}/instances'
 
 
 class InstancePath(CatalogPath):
     scheme: str
     instance: str
-    templates = [PurePosixPath('/databases/{scheme}/instances/{instance}')]
+    template = '/databases/{scheme}/instances/{instance}'
 
 
 class SchemasPath(CatalogPath):
     scheme: str
     instance: str
-    templates = [PurePosixPath('/databases/{scheme}/instances/{instance}/schemas')]
+    template = '/databases/{scheme}/instances/{instance}/schemas'
 
 
 class SchemaPath(CatalogPath):
     scheme: str
     instance: str
     schema_: str = Field(alias='schema')
-    templates = [PurePosixPath('/databases/{scheme}/instances/{instance}/schemas/{schema}')]
+    template = '/databases/{scheme}/instances/{instance}/schemas/{schema}'
 
 
 class TablesPath(CatalogPath):
     scheme: str
     instance: str
     schema_: str = Field(alias='schema')
-    templates = [PurePosixPath('/databases/{scheme}/instances/{instance}/schemas/{schema}/tables')]
+    template = '/databases/{scheme}/instances/{instance}/schemas/{schema}/tables'
 
 
 class ViewsPath(CatalogPath):
     scheme: str
     instance: str
     schema_: str = Field(alias='schema')
-    templates = [PurePosixPath('/databases/{scheme}/instances/{instance}/schemas/{schema}/views')]
+    template = '/databases/{scheme}/instances/{instance}/schemas/{schema}/views'
 
 
 class TablePath(CatalogPath):
@@ -64,7 +64,7 @@ class TablePath(CatalogPath):
     instance: str
     schema_: str = Field(alias='schema')
     table: str
-    templates = [PurePosixPath('/databases/{scheme}/instances/{instance}/schemas/{schema}/tables/{table}')]
+    template = '/databases/{scheme}/instances/{instance}/schemas/{schema}/tables/{table}'
 
 
 class ViewPath(CatalogPath):
@@ -72,7 +72,7 @@ class ViewPath(CatalogPath):
     instance: str
     schema_: str = Field(alias='schema')
     view: str
-    templates = [PurePosixPath('/databases/{scheme}/instances/{instance}/schemas/{schema}/views/{view}')]
+    template = '/databases/{scheme}/instances/{instance}/schemas/{schema}/views/{view}'
 
 
 DatabaseBrowserPath = Union[
@@ -126,7 +126,7 @@ class DatabaseBrowser(AbstractBrowser):
     ) -> list[DatabaseBrowserPath] | None:
         instance_dict = self.instance.dict(by_alias=True)
         catalog_path = create_catalog_path(
-            path,
+            str(path),
             *list(DatabaseBrowserPath.__args__), # pyright: ignore [reportGeneralTypeIssues]
         )
         catalog_path_dict = catalog_path.dict(

--- a/recap/crawler.py
+++ b/recap/crawler.py
@@ -55,29 +55,30 @@ class Crawler:
 
         while len(path_stack) > 0:
             path = path_stack.pop()
+            path_posix = PurePosixPath(str(path))
             log.info("Crawling path=%s", path)
 
             # 1. Read and save metadata for path if filters match.
-            if self._matches(path.path(), self.filters):
+            if self._matches(str(path), self.filters):
                 metadata = self._get_metadata(path)
-                self._write_metadata(path.path(), metadata)
+                self._write_metadata(path_posix, metadata)
 
             # 2. Add children (that match filter) to path_stack.
-            children = self.browser.children(path.path()) or []
+            children = self.browser.children(path_posix) or []
             filtered_children = filter(
-                lambda p: self._matches(p.path(), self.exploded_filters),
+                lambda p: self._matches(str(p), self.exploded_filters),
                 children,
             )
             path_stack.extend(filtered_children)
 
             # 3. Remove deleted children from catalog.
-            self._remove_deleted(path.path(), children)
+            self._remove_deleted(path_posix, children)
 
         log.info('Finished crawl')
 
     def _matches(
         self,
-        path: PurePosixPath,
+        path: str,
         filters: list[str],
     ) -> bool:
         """
@@ -87,7 +88,7 @@ class Crawler:
         """
 
         for filter in filters:
-            if fnmatch.fnmatch(str(path), filter):
+            if fnmatch.fnmatch(path, filter):
                 return True
         return False if filters else True
 

--- a/recap/paths.py
+++ b/recap/paths.py
@@ -9,7 +9,7 @@ class CatalogPath(BaseModel):
     Represents a path in the data catalog.
     """
 
-    templates: ClassVar[list[PurePosixPath]]
+    template: ClassVar[str]
     """
     A list of templated paths that represent the various locations of this path
     type. The template format uses Starlette's simplified URI style. For
@@ -19,9 +19,9 @@ class CatalogPath(BaseModel):
     """
 
     def name(self) -> str:
-        return self.path().parts[-1]
+        return PurePosixPath(str(self)).parts[-1]
 
-    def path(self) -> PurePosixPath:
+    def __str__(self) -> str:
         """
         Find a template format that has parameters compatible with this
         instance. If one is found, fill it in with this instance's
@@ -41,35 +41,23 @@ class CatalogPath(BaseModel):
                 schema='public']
             )
         """
-        for template in self.__class__.templates:
-            try:
-                return PurePosixPath(
-                    # TODO Should use Starlette formatting so typed variables
-                    # (e.g. {path:path} or {name:str}) are handled properly.
-                    str(template).format(**self.dict(
-                        by_alias=True,
-                        exclude_none=True,
-                        exclude_unset=True,
-                    ))
-                )
-            except KeyError:
-                pass
-        raise ValueError("No template is compatible with model variables")
-
-    def __str__(self) -> str:
-        return str(self.path())
+        # TODO Should use Starlette formatting so typed variables
+        # (e.g. {path:path} or {name:str}) are handled properly.
+        return self.template.format(**self.dict(
+                by_alias=True,
+                exclude_none=True,
+                exclude_unset=True,
+            ))
 
     @classmethod
-    def from_path(cls, path: PurePosixPath) -> Optional['CatalogPath']:
+    def from_path(cls, path: str) -> Optional['CatalogPath']:
         """
-        Construct this model from a PurePosixPath the path matches one of this
-        model's templates.
+        Construct this model from a path if it matches the template.
         """
         path_str = str(path)
-        for template in cls.templates:
-            template_regex, _, _ = compile_path(str(template))
-            if match := template_regex.match(path_str):
-                return cls(**match.groupdict())
+        template_regex, _, _ = compile_path(cls.template)
+        if match := template_regex.match(path_str):
+            return cls(**match.groupdict())
         return None
 
 
@@ -77,11 +65,11 @@ class RootPath(CatalogPath):
     """
     Canonical root path for the catalog.
     """
-    templates = [PurePosixPath('/')]
+    template = '/'
 
 
 def create_catalog_path(
-    path: PurePosixPath,
+    path: str,
     *types: Type[CatalogPath],
 ) -> CatalogPath | None:
     """


### PR DESCRIPTION
Catalog path had `templates` as a list of PurePosixPath. This annoyed me for two reasons:

1. I'm going to eliminate PurePosixPath from the API. It's typesafe but clunky. I'm going to use `str`'s instead. This is the first step.
2. Multiple templates didn't really work without a `path` variable, which I didn't want to add.

The idea behind having multiple templates was to allow a single `CatalogPath` object to be returned from different paths in the browser. I can't think of any good concrete examples of this, though, so I'm ditching it.

I didn't want to add a `path` variable to the `CatalogPath` because it felt like a dupe of the data contained in the Pydantic variables and template.