### PR TITLE
Add `AbstractBrowser.root()` and make `AbstractBrowser.children()` re…

### DIFF
--- a/docs/browsers.md
+++ b/docs/browsers.md
@@ -10,20 +10,15 @@ Different data infrastructure have different types of objects:
 
 Recap uses a _browser_ abstraction to deal with different data infrastructure in a standard way.
 
-Browsers map infrastructure objects into a standard directory format. A different browser is used for each type of infrastructure. Out of the box, Recap ships with a [DatabaseBrowser](https://github.com/recap-cloud/recap/blob/main/recap/plugins/browsers/db.py), which maps database objects into a directory structure:
+Browsers map infrastructure objects into a standard directory format. A different browser is used for each type of infrastructure. Out of the box, Recap ships with a [DatabaseBrowser](https://github.com/recap-cloud/recap/blob/main/recap/browsers/db.py), which maps database objects into a directory structure:
 
 ```
-/
-/databases
-/databases/<some_db>
-/databases/<some_db>/instances
-/databases/<some_db>/instances/<some_instance>
-/databases/<some_db>/instances/<some_instance>/schemas
-/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>
-/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>/tables
-/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>/tables/<some_view>
-/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>/views
-/databases/<some_db>/instances/<some_instance>/schemas/<some_schema>/views/<some_view>
+/schemas
+/schemas/<some_schema>
+/schemas/<some_schema>/tables
+/schemas/<some_schema>/tables/<some_view>
+/schemas/<some_schema>/views
+/schemas/<some_schema>/views/<some_view>
 ```
 
 !!! note

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -12,7 +12,7 @@ There are five types of plugins:
 
 ## Analyzers
 
-[Analyzer plugins](analyzers.md) must implement the [AbstractAnalyzer](https://github.com/recap-cloud/recap/blob/main/recap/plugins/analyzers/abstract.py) class.
+[Analyzer plugins](analyzers.md) must implement the [AbstractAnalyzer](https://github.com/recap-cloud/recap/blob/main/recap/analyzers/abstract.py) class.
 
 Packages can export their analyzers using the `recap.analyzers` entry-point. Here's how Recap's built-in analyzers are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
 
@@ -33,7 +33,7 @@ Every entry-point points to a module with a `create_analyzer(**config)` method.
 
 ## Browsers
 
-[Browser plugins](browsers.md) must implement the [AbstractBrowser](https://github.com/recap-cloud/recap/blob/main/recap/plugins/browsers/abstract.py) class.
+[Browser plugins](browsers.md) must implement the [AbstractBrowser](https://github.com/recap-cloud/recap/blob/main/recap/browsers/abstract.py) class.
 
 Packages can export their browsers using the `recap.browsers` entry-point. Here's how Recap's built-in browser is defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
 
@@ -46,7 +46,7 @@ Every entry-point points to a module with a `create_browser(**config)` method.
 
 ## Catalogs
 
-[Catalog plugins](catalogs.md) must implement the [AbstractCatalog](https://github.com/recap-cloud/recap/blob/main/recap/plugins/catalogs/abstract.py) class.
+[Catalog plugins](catalogs.md) must implement the [AbstractCatalog](https://github.com/recap-cloud/recap/blob/main/recap/catalogs/abstract.py) class.
 
 Packages can export their catalogs using the `recap.catalogs` entry-point. Here's how Recap's built-in catalogs are defined in its [pyproject.toml](https://github.com/recap-cloud/recap/blob/main/pyproject.toml):
 

--- a/recap/analyzers/db/location.py
+++ b/recap/analyzers/db/location.py
@@ -3,7 +3,7 @@ import sqlalchemy
 from contextlib import contextmanager
 from pydantic import Field
 from recap.analyzers.abstract import AbstractAnalyzer, BaseMetadataModel
-from recap.browsers.db import create_browser, InstancePath, TablePath, ViewPath
+from recap.browsers.db import create_browser, DatabaseRootPath, TablePath, ViewPath
 from typing import Generator
 
 
@@ -23,10 +23,10 @@ class Location(BaseMetadataModel):
 class TableLocationAnalyzer(AbstractAnalyzer):
     def __init__(
         self,
-        instance: InstancePath,
+        root: DatabaseRootPath,
         engine: sqlalchemy.engine.Engine,
     ):
-        self.instance = instance
+        self.root = root
         self.engine = engine
 
     def analyze(
@@ -37,8 +37,8 @@ class TableLocationAnalyzer(AbstractAnalyzer):
         table = path.table if is_table else path.view
         table_or_view = 'table' if is_table else 'view'
         location_dict = {
-            'database': self.instance.scheme,
-            'instance': self.instance.instance,
+            'database': self.root.scheme,
+            'instance': self.root.name_,
             'schema': path.schema_,
             table_or_view: table,
         }
@@ -50,4 +50,4 @@ def create_analyzer(
     **config,
 ) -> Generator['TableLocationAnalyzer', None, None]:
     with create_browser(**config) as browser:
-        yield TableLocationAnalyzer(browser.instance, browser.engine)
+        yield TableLocationAnalyzer(browser.root(), browser.engine)

--- a/recap/browsers/abstract.py
+++ b/recap/browsers/abstract.py
@@ -8,44 +8,52 @@ class AbstractBrowser(ABC):
     The abstract class for all browsers. Recap uses a browser abstraction to
     deal with different data infrastructure in a standard way.
 
-    Browsers map infrastructure objects into a standard directory format. A
-    different browser is used for each type of infrastructure.
+    Browsers map infrastructure objects into a directory format. A different
+    browser is used for each type of infrastructure.
 
     A DatabaseBrowser might list directories like this:
 
-        /
-        /databases
-        /databases/postgresql
-        /databases/postgresql/instances
-        /databases/postgresql/instances/localhost
-        /databases/postgresql/instances/localhost/schemas
-        /databases/postgresql/instances/localhost/schemas/public
-        /databases/postgresql/instances/localhost/schemas/public/tables
-        /databases/postgresql/instances/localhost/schemas/public/tables/groups
-        /databases/postgresql/instances/localhost/schemas/public/tables/users
+        /schemas
+        /schemas/public
+        /schemas/public/tables
+        /schemas/public/tables/groups
+        /schemas/public/tables/users
     """
 
     @abstractmethod
     def children(self, path: PurePosixPath) -> list[CatalogPath] | None:
         """
         Given a path, returns its children. Using the example above,
-        path=/databases/postgresql/instances/localhost/schemas/public/tables
-        would return:
+        path=/schemas/public/tables would return:
 
             [
                 TablePath(
-                    scheme='postgresl',
-                    instance='localhost',
                     schema='public',
                     table='groups',
                 ),
                 TablePath(
-                    scheme='postgresl',
-                    instance='localhost',
                     schema='public',
                     table='users',
                 ),
             ]
+
+        The path parameter is relative; it does not include the browser's root.
         """
 
+        raise NotImplementedError
+
+    @abstractmethod
+    def root(self) -> CatalogPath:
+        """
+        The root path for this browser. The root path is prefixed to all
+        paths when persisting metdata to a catalog.
+
+        Using the example above, root might return something like:
+
+            /databases/postgresql/instances/prd-db
+
+        Thus, the full catalog path for the `users` table would be:
+
+            /databases/postgresql/instances/prd-db/schemas/public/tables/users
+        """
         raise NotImplementedError


### PR DESCRIPTION
…lative

I got rid of `AbstractBrowser.root()` a while ago--the browser API was kind of messy then. Now that it's more cleaned up, having a `root()` method is valuable. It greatly simplifies the number of `CatalogPath`s that a browser needs to declare. It also should theoretically make it possible for `AbstractAnalyzer`s to have an `analyze()` method that declares kwargs instead of a typed Catalog path, e.g.:

```
def analyze(
    schema: str,
    table: str,
):
```

The crawler could pass arguments to the analyers using `**model.dict(by_alias=True)`. This is something I experimented with, but never liked because the extra attributes from the root (`name` and `scheme` for the `DatabaseBrowserPath`s) were passed in, which forced `analyze()` to have a `**_` at the end. Now that the root is excluded, this optioon looks more viable.