### PR TITLE
Remove `PurePosixPath` from APIs

### DIFF
--- a/recap/browsers/abstract.py
+++ b/recap/browsers/abstract.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from pathlib import PurePosixPath
 from recap.paths import CatalogPath
 
 
@@ -21,7 +20,7 @@ class AbstractBrowser(ABC):
     """
 
     @abstractmethod
-    def children(self, path: PurePosixPath) -> list[CatalogPath] | None:
+    def children(self, path: str) -> list[CatalogPath] | None:
         """
         Given a path, returns its children. Using the example above,
         path=/schemas/public/tables would return:

--- a/recap/browsers/db.py
+++ b/recap/browsers/db.py
@@ -2,7 +2,6 @@ import logging
 import sqlalchemy
 from .abstract import AbstractBrowser
 from contextlib import contextmanager
-from pathlib import PurePosixPath
 from pydantic import Field
 from recap.paths import CatalogPath, RootPath, create_catalog_path
 from typing import Any, Callable, Generator, Union
@@ -92,10 +91,10 @@ class DatabaseBrowser(AbstractBrowser):
 
     def children(
         self,
-        path: PurePosixPath,
+        path: str,
     ) -> list[DatabaseBrowserPath] | None:
         catalog_path = create_catalog_path(
-            str(path),
+            path,
             *list(DatabaseBrowserPath.__args__), # pyright: ignore [reportGeneralTypeIssues]
         )
         match catalog_path:

--- a/recap/catalogs/abstract.py
+++ b/recap/catalogs/abstract.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from pathlib import PurePosixPath
 from typing import Any
 
 
@@ -14,7 +13,7 @@ class AbstractCatalog(ABC):
     @abstractmethod
     def touch(
         self,
-        path: PurePosixPath,
+        path: str,
     ):
         """
         Creates an empty directory.
@@ -25,7 +24,7 @@ class AbstractCatalog(ABC):
     @abstractmethod
     def write(
         self,
-        path: PurePosixPath,
+        path: str,
         type: str,
         metadata: Any,
     ):
@@ -42,7 +41,7 @@ class AbstractCatalog(ABC):
     @abstractmethod
     def rm(
         self,
-        path: PurePosixPath,
+        path: str,
         type: str | None = None,
     ):
         """
@@ -57,7 +56,7 @@ class AbstractCatalog(ABC):
     @abstractmethod
     def ls(
         self,
-        path: PurePosixPath,
+        path: str,
         as_of: datetime | None = None,
     ) -> list[str] | None:
         """
@@ -73,7 +72,7 @@ class AbstractCatalog(ABC):
     @abstractmethod
     def read(
         self,
-        path: PurePosixPath,
+        path: str,
         as_of: datetime | None = None,
     ) -> dict[str, Any] | None:
         """

--- a/recap/catalogs/recap.py
+++ b/recap/catalogs/recap.py
@@ -2,7 +2,6 @@ import httpx
 from .abstract import AbstractCatalog
 from contextlib import contextmanager
 from datetime import datetime
-from pathlib import PurePosixPath
 from recap.server import DEFAULT_URL
 from typing import Any, Generator
 
@@ -21,13 +20,13 @@ class RecapCatalog(AbstractCatalog):
 
     def touch(
         self,
-        path: PurePosixPath,
+        path: str,
     ):
-        self.client.put(str(path))
+        self.client.put(path)
 
     def write(
         self,
-        path: PurePosixPath,
+        path: str,
         type: str,
         metadata: Any,
     ):
@@ -41,7 +40,7 @@ class RecapCatalog(AbstractCatalog):
 
     def rm(
         self,
-        path: PurePosixPath,
+        path: str,
         type: str | None = None,
     ):
         if type:
@@ -52,7 +51,7 @@ class RecapCatalog(AbstractCatalog):
 
     def ls(
         self,
-        path: PurePosixPath,
+        path: str,
         as_of: datetime | None = None,
     ) -> list[str] | None:
         params: dict[str, Any] = {}
@@ -67,7 +66,7 @@ class RecapCatalog(AbstractCatalog):
 
     def read(
         self,
-        path: PurePosixPath,
+        path: str,
         as_of: datetime | None = None,
     ) -> dict[str, Any] | None:
         params: dict[str, Any] = {}

--- a/recap/commands/catalog.py
+++ b/recap/commands/catalog.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from recap import catalogs
 from recap.config import settings
 from rich import print_json
-from pathlib import PurePosixPath
 
 
 app = typer.Typer(help="Read and search the data catalog.")
@@ -42,7 +41,7 @@ def list_(
     """
 
     with catalogs.create_catalog(**settings('catalog', {})) as c:
-        results = sorted(c.ls(PurePosixPath(path), as_of) or [])
+        results = sorted(c.ls(path, as_of) or [])
         print_json(data=results)
 
 
@@ -60,5 +59,5 @@ def read(
     """
 
     with catalogs.create_catalog(**settings('catalog', {})) as c:
-        results = c.read(PurePosixPath(path), as_of) or []
+        results = c.read(path, as_of) or []
         print_json(data=results, sort_keys=True)

--- a/recap/paths.py
+++ b/recap/paths.py
@@ -19,7 +19,7 @@ class CatalogPath(BaseModel):
     """
 
     def name(self) -> str:
-        return PurePosixPath(str(self)).parts[-1]
+        return PurePosixPath(str(self)).name
 
     def __str__(self) -> str:
         """

--- a/recap/routers/directory.py
+++ b/recap/routers/directory.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException
-from pathlib import PurePosixPath
 from recap.catalogs.abstract import AbstractCatalog
 from recap.server import get_catalog
 
@@ -12,12 +11,11 @@ router = APIRouter(
 
 @router.get("/{path:path}")
 def list_directory(
-    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
     path: str,
     as_of: datetime | None = None,
     catalog: AbstractCatalog = Depends(get_catalog),
 ) -> list[str]:
-    children = catalog.ls(PurePosixPath(path), as_of)
+    children = catalog.ls(path, as_of)
     if children:
         return children
     raise HTTPException(status_code=404)
@@ -25,17 +23,15 @@ def list_directory(
 
 @router.put("/{path:path}")
 def make_directory(
-    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
     path: str,
     catalog: AbstractCatalog = Depends(get_catalog),
 ):
-    catalog.touch(PurePosixPath(path))
+    catalog.touch(path)
 
 
 @router.delete("/{path:path}")
 def remove_directory(
-    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
     path: str,
     catalog: AbstractCatalog = Depends(get_catalog),
 ):
-    catalog.rm(PurePosixPath(path))
+    catalog.rm(path)

--- a/recap/routers/metadata.py
+++ b/recap/routers/metadata.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from fastapi import APIRouter, Body, Depends, HTTPException
-from pathlib import PurePosixPath
 from typing import Any
 from recap.catalogs.abstract import AbstractCatalog
 from recap.server import get_catalog
@@ -13,13 +12,11 @@ router = APIRouter(
 
 @router.get("/{path:path}")
 def read_metadata(
-    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
     path: str,
     as_of: datetime | None = None,
     catalog: AbstractCatalog = Depends(get_catalog),
 ) -> dict[str, Any]:
-    # TODO should probably return a 404 if we get None from storage
-    metadata = catalog.read(PurePosixPath(path), as_of)
+    metadata = catalog.read(path, as_of)
     if metadata:
         return metadata
     raise HTTPException(status_code=404)
@@ -27,20 +24,18 @@ def read_metadata(
 
 @router.patch("/{path:path}")
 def patch_metadata(
-    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
     path: str,
     type: str,
     metadata: Any = Body(),
     catalog: AbstractCatalog = Depends(get_catalog),
 ):
-    catalog.write(PurePosixPath(path), type, metadata)
+    catalog.write(path, type, metadata)
 
 
 @router.delete("/{path:path}")
 def delete_metadata(
-    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
     path: str,
     type: str | None = None,
     catalog: AbstractCatalog = Depends(get_catalog),
 ):
-    catalog.rm(PurePosixPath(path), type)
+    catalog.rm(path, type)


### PR DESCRIPTION
Exposing PurePosixPath in APIs is cumbersome, even though it's more typesafe than `str`. Given that `str` appears to be idiomatic in Python-land, I'm going to go with it. I still use PurePosixPath in a few spots to make sure paths are properly formatted, but I no longer expose it in the API at all.