### PR TITLE
Exclude default, none, and unset in REST API

### DIFF
--- a/recap/routers/catalog/typed.py
+++ b/recap/routers/catalog/typed.py
@@ -15,7 +15,7 @@ from typing import Callable
 
 
 router = APIRouter(
-    prefix="/catalog"
+    prefix="/catalog",
 )
 
 
@@ -55,6 +55,10 @@ def add_route(
         dependencies=[Depends(get_catalog)],
         response_model=metadata_class if method == 'GET' else None,
         methods=[method],
+        # These only apply for GET, but no harm in including them for all.
+        response_model_exclude_defaults=True,
+        response_model_exclude_none=True,
+        response_model_exclude_unset=True,
     )
 
 

--- a/recap/routers/catalog/untyped.py
+++ b/recap/routers/catalog/untyped.py
@@ -8,11 +8,16 @@ from typing import Any
 
 
 router = APIRouter(
-    prefix="/catalog"
+    prefix="/catalog",
 )
 
 
-@router.get("/{path:path}/metadata")
+@router.get(
+    "/{path:path}/metadata",
+    response_model_exclude_defaults=True,
+    response_model_exclude_none=True,
+    response_model_exclude_unset=True,
+)
 def read_metadata(
     path: str,
     as_of: datetime | None = None,
@@ -37,16 +42,10 @@ def patch_metadata(
 @router.put("/{path:path}/metadata")
 def put_metadata(
     path: str,
-    metadata: BaseModel = Body(),
+    metadata: dict[str, Any] = Body(),
     catalog: AbstractCatalog = Depends(get_catalog),
 ):
-    metadata_ = metadata.dict(
-        by_alias=True,
-        exclude_defaults=True,
-        exclude_none=True,
-        exclude_unset=True,
-    )
-    catalog.write(clean_path(path), metadata_)
+    catalog.write(clean_path(path), metadata)
 
 
 @router.get("/{path:path}/children")


### PR DESCRIPTION
The REST API was, somewhat annoyingly, returning default, null, and unset fields for Pydantic models. I've updated it to exclude such fields; to leave the client to their own devices when handling unset variables. I suppose some clients may care about the difference between null and unset, but I'm going to leave that for another day.

Closes #120