### PR TITLE
Add `recap analyze` command

### DIFF
--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -1,14 +1,14 @@
 Recap analyzers generate metadata; they're given a path and return a [Pydantic](https://pydantic.dev) model with the metadata the analyzer discovered.
 
-!!! note
+## Commands
 
-    `recap crawl` will run all available analyzers. You can exclude analyzers using `--exclude`. See the [commands](commands.md) documentation for more information.
+### Analyze
 
-## Analyzer Names
+`recap analyze` will run a specific analyzer directly on a system (rather than fetching metadata from Recap's data catalog). See the [commands](commands.md#analyze) page for more information.
 
-Analyzers have a namespace prefix to differentiate analyzers that return similar data. For example, the SQLAlchemy's `sqlalchemy.columns` analyzer returns column schemas in the standard SQLAlchemy schema format. A more specific `snowflake.columns` analyzer could return a more Snowflake-specific schema.
+### Crawl
 
-Clients can decide which analyzer metadata to pay attention to. They can also use specific metadata if available, but fall back to more generic metadata otherwise.
+`recap crawl` will run all available analyzers when crawling one or more systems. You can exclude analyzers using `--exclude`. See the [commands](commands.md#crawl) documentation for more information.
 
 ## Database Analyzers
 
@@ -25,6 +25,10 @@ Recap ships with the following analyzer plugins:
 * `sqlalchemy.view_definition`
 
 Other analyzers will be available if you've installed additional [analyzer plugins](plugins.md#analyzers). Run `recap plugins analyzers` to see a complete list.
+
+!!! note
+
+    Analyzers namespace prefixes differentiate analyzers that return similar data. The SQLAlchemy `sqlalchemy.columns` analyzer returns column schemas in the standard SQLAlchemy schema format. A more specific `snowflake.columns` analyzer could return a more Snowflake-specific schema. Clients decide which analyzer metadata to use.
 
 ### Access
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,5 +1,6 @@
-Recap ships with four standard command plugins:
+Recap ships with several standard command plugins:
 
+* `recap analyze`
 * `recap catalog`
 * `recap crawl`
 * `recap plugins`
@@ -9,9 +10,21 @@ Recap ships with four standard command plugins:
 
     You can see all available commands by running `recap --help` or `recap plugins commands`.
 
+## Analyze
+
+`recap analyze` analyzes and fetches current metadata directly from a system, rather than going through Recap's catalog. You can use `recap analyze` to see exactly what the system's data looks like right now, rather than reading the catalog cache.
+
+```
+recap analyze sqlalchemy.columns postgresql://username@localhost/some_db /schemas/some_db/tables/some_table
+```
+
+Any available [analyzer plugin](plugins.md#analyzers) name may be used (in the example, we use `sqlalchemy.columns`). Run `recap plugins analyzers` to list available plugins.
+
+[Configuration](configuration.md) for the URL can be set using the standard `settings.toml` file.
+
 ## Catalog
 
-Recaps `recap catalog` command reads metadata Recap's data catalog. List the catalog's directory structure with `recap list`, read metadata from a directory with `recap read`, and search with `recap search`.
+Recap's `recap catalog` command reads metadata Recap's data catalog. List the catalog's directory structure with `recap list`, read metadata from a directory with `recap read`, and search with `recap search`.
 
 ### Search
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ db = "recap.catalogs.db"
 recap = "recap.catalogs.recap"
 
 [project.entry-points."recap.commands"]
+analyze = "recap.commands.analyze:app"
 catalog = "recap.commands.catalog:app"
 crawl = "recap.commands.crawl:app"
 plugins = "recap.commands.plugins:app"

--- a/recap/commands/analyze.py
+++ b/recap/commands/analyze.py
@@ -1,0 +1,65 @@
+import typer
+from recap.analyzers import create_analyzer
+from recap.config import settings
+from recap.paths import create_catalog_path
+from recap.typing import AnalyzerInspector
+from rich import print_json
+
+
+app = typer.Typer()
+
+
+@app.command(
+    context_settings={
+        "allow_extra_args": True,
+        "ignore_unknown_options": True,
+    },
+)
+def analyze(
+    plugin: str = typer.Argument(...,
+        help="Analyzer plugin name. Run `recap plugins analyzers` to get a full list.",
+    ),
+    url: str = typer.Argument(...,
+        help="URL to crawl. URL configs in settings.toml will be used, if availabe.",
+    ),
+    path: str = typer.Argument(...,
+        help="Path to analyze.",
+    ),
+):
+    """
+    Analyzes and returns metadata for a URL and path.
+    """
+
+    crawlers_configs = settings('crawlers', [])
+    crawler_urls = set(map(
+        lambda c: c.get('url'),
+        crawlers_configs,
+    ))
+
+    if url and url not in crawler_urls:
+        crawlers_configs.append({'url': url})
+
+    for crawler_config in crawlers_configs:
+        if url == crawler_config['url']:
+            with create_analyzer(plugin, **crawler_config) as analyzer:
+                inspector = AnalyzerInspector(type(analyzer))
+                if catalog_path := create_catalog_path(
+                    path,
+                    *inspector.input_path_types(),
+                ):
+                    if metadata := analyzer.analyze(catalog_path):
+                        metadata_dict = metadata.dict(
+                            by_alias=True,
+                            exclude_defaults=True,
+                            exclude_none=True,
+                            exclude_unset=True,
+                        )
+                        return_dict = metadata_dict.get(
+                            '__root__',
+                            metadata_dict,
+                        )
+                        print_json(data=return_dict, sort_keys=True)
+                else:
+                    raise ValueError(
+                        f"Invalid path={path} for analyzer={plugin}",
+                    )


### PR DESCRIPTION
Users can now analyze metadata on a system directly, rather than fetching cached data from the Recap catalog:

```
recap analyze db.column \
    postgresql://username@localhost/some_db \
    /schema/public/tables/some_table
```

Closes #118