### PR TITLE
Change `--as-of` and `-a` to `--time` and `-t` in CLI

### DIFF
--- a/recap/commands/catalog.py
+++ b/recap/commands/catalog.py
@@ -12,7 +12,7 @@ app = typer.Typer(help="Read and search the data catalog.")
 def search(
     query: str,
     time: datetime = typer.Option(
-        None, '--as-of', '-a',
+        None, '--time', '-t',
         help=\
             "View metadata as of a point in time.",
     ),
@@ -31,7 +31,7 @@ def search(
 def list_(
     path: str = typer.Argument('/'),
     time: datetime = typer.Option(
-        None, '--as-of', '-a',
+        None, '--time', '-t',
         help=\
             "View metadata as of a point in time.",
     ),
@@ -49,7 +49,7 @@ def list_(
 def read(
     path: str,
     time: datetime = typer.Option(
-        None, '--as-of', '-a',
+        None, '--time', '-t',
         help=\
             "View metadata as of a point in time.",
     ),


### PR DESCRIPTION
This is a very minor follow-on fix to #130. I noticed the CLI still has `as-of` in a few spots; probably escaped the grep search.