### PR TITLE
Add `recap browse` command

### DIFF
--- a/docs/browsers.md
+++ b/docs/browsers.md
@@ -34,3 +34,9 @@ So, a DatabaseBrowser for a PostgreSQL might have a path like:
     /databases/postgresql/instances/prd-profile-db
 
 This full directory path (including the root) is what you use when you run `recap catalog list` and `recap catalog read`. The directory structure is also used when executing `recap crawl` with a `--filter` option.
+
+## Commands
+
+### Browse
+
+`recap browse` fetches children for a path in a system rather than going through Recap's catalog. See the [commands](commands.md#browse) page for more information.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,13 +12,23 @@ Recap ships with several standard command plugins:
 
 ## Analyze
 
-`recap analyze` analyzes and fetches current metadata directly from a system, rather than going through Recap's catalog. You can use `recap analyze` to see exactly what the system's data looks like right now, rather than reading the catalog cache.
+Use `recap analyze` to see the system's metadata at the moment the command is run. `recap analyze` analyzes and fetches current metadata directly from a system rather than going through Recap's catalog.
 
 ```
 recap analyze sqlalchemy.columns postgresql://username@localhost/some_db /schemas/some_db/tables/some_table
 ```
 
 Any available [analyzer plugin](plugins.md#analyzers) name may be used (in the example, we use `sqlalchemy.columns`). Run `recap plugins analyzers` to list available plugins.
+
+[Configuration](configuration.md) for the URL can be set using the standard `settings.toml` file.
+
+## Browse
+
+Use `recap browse` to see the system's directory sturcture at the moment the command is run. `recap browse` fetches children for a path in a system rather than going through Recap's catalog.
+
+```
+recap browse postgresql://username@localhost/some_db /schemas/some_db/
+```
 
 [Configuration](configuration.md) for the URL can be set using the standard `settings.toml` file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ recap = "recap.catalogs.recap"
 
 [project.entry-points."recap.commands"]
 analyze = "recap.commands.analyze:app"
+browse = "recap.commands.browse:app"
 catalog = "recap.commands.catalog:app"
 crawl = "recap.commands.crawl:app"
 plugins = "recap.commands.plugins:app"

--- a/recap/commands/analyze.py
+++ b/recap/commands/analyze.py
@@ -9,18 +9,13 @@ from rich import print_json
 app = typer.Typer()
 
 
-@app.command(
-    context_settings={
-        "allow_extra_args": True,
-        "ignore_unknown_options": True,
-    },
-)
+@app.command()
 def analyze(
     plugin: str = typer.Argument(...,
         help="Analyzer plugin name. Run `recap plugins analyzers` to get a full list.",
     ),
     url: str = typer.Argument(...,
-        help="URL to crawl. URL configs in settings.toml will be used, if availabe.",
+        help="URL to analyze. URL configs in settings.toml will be used, if availabe.",
     ),
     path: str = typer.Argument(...,
         help="Path to analyze.",

--- a/recap/commands/browse.py
+++ b/recap/commands/browse.py
@@ -1,0 +1,54 @@
+import logging
+import typer
+from pathlib import PurePosixPath
+from recap.browsers import create_browser
+from recap.config import settings
+from recap.plugins import load_browser_plugins
+from rich import print_json
+
+
+app = typer.Typer()
+log = logging.getLogger(__name__)
+
+
+@app.command()
+def browse(
+    url: str = typer.Argument(...,
+        help="URL to browse. URL configs in settings.toml will be used, if availabe.",
+    ),
+    path: str = typer.Argument(
+        '/',
+        help="Path to list children for.",
+    ),
+):
+    """
+    Returns children for a URL and path.
+    """
+
+    clean_path = str(PurePosixPath(path))
+    browser_plugins = load_browser_plugins()
+    crawlers_configs = settings('crawlers', [])
+    crawler_urls = set(map(
+        lambda c: c.get('url'),
+        crawlers_configs,
+    ))
+
+    if url and url not in crawler_urls:
+        crawlers_configs.append({'url': url})
+
+    for crawler_config in crawlers_configs:
+        if url == crawler_config['url']:
+            for browser_name in browser_plugins.keys():
+                try:
+                    with create_browser(browser_name, **crawler_config) as browser:
+                        if children := browser.children(clean_path):
+                            print_json(data=sorted([c.name() for c in children]))
+                        else:
+                            print_json(data=[])
+                except Exception as e:
+                        log.debug(
+                            'Skipped browser for url=%s name=%s',
+                            url,
+                            browser_name,
+                            exc_info=e,
+                        )


### PR DESCRIPTION
Users can now browse a system's directory structure directly rather than fetching cached data from the Recap catalog:

    recap browse postgresql://username@localhost/some_db/schemas

Closes #119