### PR TITLE
Change `api.*` config to `server.uvicorn.*` and add `server.plugins` …

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -6,13 +6,20 @@ Execute `recap serve` to start Recap's server.
 
 ## Configuring
 
-Recap's server is implemented as a [FastAPI](https://fastapi.tiangolo.com/) in a [uvicorn](https://www.uvicorn.org/) web server. Any configuration set in your `settings.toml` file under the `api` namespace will be passed to Recap's `uvicorn.run` invocation.
+Recap's server is implemented as a [FastAPI](https://fastapi.tiangolo.com/) in a [uvicorn](https://www.uvicorn.org/) web server. Any configuration set in your `settings.toml` file under the `server.uvicorn` namespace will be passed to Recap's `uvicorn.run` invocation.
 
 ```toml
-[api]
-host = "192.168.0.1"
-port = 9000
-access_log = false
+[server]
+uvicorn.port = 9000
+```
+
+You can also enable only certain [router plugins](plugins.md#routers) using the `server.plugins` setting:
+
+```toml
+[server]
+plugins = [
+	"catalog.typed"
+]
 ```
 
 ## Endpoints
@@ -24,7 +31,7 @@ Recap has the following endpoints:
 * GET `/catalog/{path}/children` - List a path's child directories.
 * DELETE `/catalog/{path}` - Delete a path, its metadata, and its children.
 
-Recap's JSON schema is visible at [http://localhost:8000/openapi.json](http://localhost:8000/openapi.json) when you start the server with the `recap server` command. API documentation is also visible at [http://localhost:8000/docs](http://localhost:8000/docs) and [http://localhost:8000/redoc](http://localhost:8000/redoc). Recap's catalog [source code](https://github.com/recap-cloud/recap/blob/main/recap/catalogs/recap.py) illustrates how to call Recap server.
+Recap's JSON schema is visible at [http://localhost:8000/openapi.json](http://localhost:8000/openapi.json). API documentation is also visible at [http://localhost:8000/docs](http://localhost:8000/docs) and [http://localhost:8000/redoc](http://localhost:8000/redoc).
 
 ## Models
 

--- a/recap/commands/serve.py
+++ b/recap/commands/serve.py
@@ -18,5 +18,5 @@ def serve():
     uvicorn.run(
         fastapp,
         log_config=setup_logging(),
-        **settings('api', {}),
+        **settings('server.uvicorn', {}),
     )

--- a/recap/server.py
+++ b/recap/server.py
@@ -18,6 +18,8 @@ def get_catalog() -> Generator[AbstractCatalog, None, None]:
 
 @fastapp.on_event("startup")
 def load_plugins():
+    allowed_plugins = settings('server.plugins', [])
     router_plugins = plugins.load_router_plugins()
-    for plugin_router in router_plugins.values():
-        fastapp.include_router(plugin_router)
+    for plugin_name, plugin_router in router_plugins.items():
+        if not allowed_plugins or plugin_name in allowed_plugins:
+            fastapp.include_router(plugin_router)


### PR DESCRIPTION
…filter

Users can now control which server routers are enabled using the `server.plugins` config:

```
[server]
plugins = [
    "catalog.typed"
]
```

I also changed the `api` namespace to `server.uvicorn` for uvicorn settings.

Closes #109