### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "recap-core"
-version = "0.3.1"
+version = "0.4.0"
 description = "A dead simple data catalog for engineers"
 authors = [
     {name = "Chris Riccomini", email = "criccomini@apache.org"},


### PR DESCRIPTION
I just released 0.3.1, so time to bump. I think the next release will be a minor, not patch release, so bumping to 0.4.0.