### PR TITLE
Fix server bugs discovered from `FilesystemBrowser`

### DIFF
--- a/recap/browsers/fs.py
+++ b/recap/browsers/fs.py
@@ -68,7 +68,7 @@ class FilesystemBrowser(AbstractBrowser):
                 paths.append(path_type(path=child_path))
         return paths
 
-    def root(self) -> CatalogPath:
+    def root(self) -> FilesystemRootPath:
         return self.root_
 
     @staticmethod


### PR DESCRIPTION
I discovered a couple of bugs that broke the server after `FilesystemBrowser` was added.

1. The `FilesystemBrowser.root()` method was returning a generic `CatalogPath`. It needs to return a specific subtype so that the server can `str()` it to get the HTTP path.
2. The `typed.py` code was still formatting CatalogPath templates using .format() rather than Starlette's URI format syntax. This broke with FilePath and DirectoryPath because they both have a `{path:path}` param in their path, which `.format()` doesn't understand.