### PR TITLE
Add DuckDB `FileColumnAnalyzer`s for CSV, TSV, and Parquet

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -140,6 +140,14 @@ requires_python = ">=3.5"
 summary = "Decorators for Humans"
 
 [[package]]
+name = "duckdb"
+version = "0.6.1"
+summary = "DuckDB embedded database"
+dependencies = [
+    "numpy>=1.14",
+]
+
+[[package]]
 name = "dynaconf"
 version = "3.1.11"
 requires_python = ">=3.7"
@@ -933,7 +941,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:f8f78e33064da45b8f0f412557a23655e3c49a408c1d574543c400e219831156"
+content_hash = "sha256:d6ea338f3256e3e27438b95e952fe41287dc7adceb4fa01f0f4ad07791eb7d8b"
 
 [metadata.files]
 "aiobotocore 2.4.2" = [
@@ -1178,6 +1186,55 @@ content_hash = "sha256:f8f78e33064da45b8f0f412557a23655e3c49a408c1d574543c400e21
 "decorator 5.1.1" = [
     {url = "https://files.pythonhosted.org/packages/66/0c/8d907af351aa16b42caae42f9d6aa37b900c67308052d10fdce809f8d952/decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
     {url = "https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+]
+"duckdb 0.6.1" = [
+    {url = "https://files.pythonhosted.org/packages/01/09/f54f14b256a7b4cc928bffeacd5520b40e3baeb54c7f4131ffc9b35af122/duckdb-0.6.1-cp36-cp36m-win32.whl", hash = "sha256:546a1cd17595bd1dd009daf6f36705aa6f95337154360ce44932157d353dcd80"},
+    {url = "https://files.pythonhosted.org/packages/09/4d/5baca267898d4d290a9dabe3d6d023cba38fb1774234f7fa4cc069a02638/duckdb-0.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fec2c2466654ce786843bda2bfba71e0e4719106b41d36b17ceb1901e130aa71"},
+    {url = "https://files.pythonhosted.org/packages/14/ea/1df38c8d38fd83e766dee978cde7fa3c4799cd4ed3de40b76de62daecc3e/duckdb-0.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c7155cb93ab432eca44b651256c359281d26d927ff43badaf1d2276dd770832"},
+    {url = "https://files.pythonhosted.org/packages/18/38/04ad06607c9b537ed0db64cab5ddc397c72ef21d66db830892124792f6ba/duckdb-0.6.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d218c2dd3bda51fb79e622b7b2266183ac9493834b55010aa01273fa5b7a7105"},
+    {url = "https://files.pythonhosted.org/packages/1d/77/6bc4ebcc95986ce57c74e94066f9a668b8508d32b0a07a427eb92b11e19f/duckdb-0.6.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c35ff4b1117096ef72d101524df0079da36c3735d52fcf1d907ccffa63bd6202"},
+    {url = "https://files.pythonhosted.org/packages/1e/5e/8b7472fdaedce2a3eed50da24335bfa81ca5dbca66d6b684a1646ab52727/duckdb-0.6.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35b01bc724e1933293f4c34f410d2833bfbb56d5743b515d805bbfed0651476e"},
+    {url = "https://files.pythonhosted.org/packages/1f/19/9c6f9a8b05335d60b590e7039dc7830a7c78e8e39d0b4b04d9e49de1e4ac/duckdb-0.6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:87b0d00eb9d1a7ebe437276203e0cdc93b4a2154ba9688c65e8d2a8735839ec6"},
+    {url = "https://files.pythonhosted.org/packages/21/e5/4d6832d593b29e4e16fca194fcabdb66f1cafb9dafee7d1439f742435999/duckdb-0.6.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ce376966260eb5c351fcc6af627a979dbbcae3efeb2e70f85b23aa45a21e289d"},
+    {url = "https://files.pythonhosted.org/packages/2a/d8/aa2facdb198cab383221c5e13a7738f09830e3989908b02abd1cab682a0b/duckdb-0.6.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4b280b2d8a01ecd4fe2feab041df70233c534fafbe33a38565b52c1e017529c7"},
+    {url = "https://files.pythonhosted.org/packages/2e/d7/0320924f9e817442afad06a5e428e8f5fb55b6cb20bfd2b0be4b3975ec08/duckdb-0.6.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b4bbe2f6c1b109c626f9318eee80934ad2a5b81a51409c6b5083c6c5f9bdb125"},
+    {url = "https://files.pythonhosted.org/packages/30/b4/5f7f1d46392bbf0d95ebc53762b18228fd7331c7f9eebb72469469419672/duckdb-0.6.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e609a65b31c92f2f7166831f74b56f5ed54b33d8c2c4b4c3974c26fdc50464c5"},
+    {url = "https://files.pythonhosted.org/packages/31/5f/b80d14bd20e54915cec622b8bd1d6a36147e63bef93bad1487306242c806/duckdb-0.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:afa97d982dbe6b125631a17e222142e79bee88f7a13fc4cee92d09285e31ec83"},
+    {url = "https://files.pythonhosted.org/packages/35/53/d85036800c1672f15e178a623b2fcb3ac203664cbfa54180c39c74ad4102/duckdb-0.6.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:125ba45e8b08f28858f918ec9cbd3a19975e5d8d9e8275ef4ad924028a616e14"},
+    {url = "https://files.pythonhosted.org/packages/38/f8/257c3f72a2dcd7397492791baca7aaec15015ebd2b2d5780070ffb868f18/duckdb-0.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f4edcaa471d791393e37f63e3c7c728fa6324e3ac7e768b9dc2ea49065cd37cc"},
+    {url = "https://files.pythonhosted.org/packages/47/8d/140845f6f61f9fe936f5743fedb6625c0ff4781f3be928e4d3a20d551fc7/duckdb-0.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:16fa96ffaa3d842a9355a633fb8bc092d119be08d4bc02013946d8594417bc14"},
+    {url = "https://files.pythonhosted.org/packages/48/80/0dee966cde56d2e1b3ea8e3389b2e93288d662bc0b85b6b0508f3151f3c0/duckdb-0.6.1.tar.gz", hash = "sha256:6d26e9f1afcb924a6057785e506810d48332d4764ddc4a5b414d0f2bf0cacfb4"},
+    {url = "https://files.pythonhosted.org/packages/55/d9/d80159f4304e351db0459a16e9c8d139c87a495300007cc105b75452c30f/duckdb-0.6.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:82cd30f5cf368658ef879b1c60276bc8650cf67cfe3dc3e3009438ba39251333"},
+    {url = "https://files.pythonhosted.org/packages/5c/ad/1186693bc6d73f5ba1ac4e13772ba57abfcc970aa03ccdfb8c7405b039f1/duckdb-0.6.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a782bbfb7f5e97d4a9c834c9e78f023fb8b3f6687c22ca99841e6ed944b724da"},
+    {url = "https://files.pythonhosted.org/packages/66/19/ca4d3bc96cc04361f917d1c25a45583326a341007741b57dddf6eb666f8a/duckdb-0.6.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5054792f22733f89d9cbbced2bafd8772d72d0fe77f159310221cefcf981c680"},
+    {url = "https://files.pythonhosted.org/packages/67/18/27d0b0b6d9cf1ecbe9d6abdd26e9788b10288ac20bd9426dcf2f39b1c299/duckdb-0.6.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:73c974b09dd08dff5e8bdedba11c7d0aa0fc46ca93954ee7d19e1e18c9883ac1"},
+    {url = "https://files.pythonhosted.org/packages/6c/78/06db249ac103d2fede9a2fd3c74571ea2ff96204fb67ecf1b569ad8fac27/duckdb-0.6.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:21cc503dffc2c68bb825e4eb3098e82f40e910b3d09e1b3b7f090d39ad53fbea"},
+    {url = "https://files.pythonhosted.org/packages/74/ad/271475c8b9c4bf42b4c59946eb9e1f1a0177966f02850804f62c4e81657d/duckdb-0.6.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e92dd6aad7e8c29d002947376b6f5ce28cae29eb3b6b58a64a46cdbfc5cb7943"},
+    {url = "https://files.pythonhosted.org/packages/78/cc/508a045cb18164d0890eb09f38bc7f8346aa03c387217c71aeeab1be61ec/duckdb-0.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:93b074f473d68c944b0eeb2edcafd91ad11da8432b484836efaaab4e26351d48"},
+    {url = "https://files.pythonhosted.org/packages/79/a7/c01998a05ed41fd3bf124079de9508ee6002e5b120a4ba353817535eaa7a/duckdb-0.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cfea36b58928ce778d17280d4fb3bf0a2d7cff407667baedd69c5b41463ac0fd"},
+    {url = "https://files.pythonhosted.org/packages/7b/dd/3439c82a6bc61c677098ba0d1216665321d0624ef6d0e3bb2cc79c3c9616/duckdb-0.6.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7363ffe857d00216b659116647fbf1e925cb3895699015d4a4e50b746de13041"},
+    {url = "https://files.pythonhosted.org/packages/7f/fa/d79b39cec15fd227c7174108f24541bd69fc7f1751ec2cf02099055e2592/duckdb-0.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:143611bd1b7c13343f087d4d423a7a8a4f33a114c5326171e867febf3f0fcfe1"},
+    {url = "https://files.pythonhosted.org/packages/84/8f/72a0be1eb246471b58162eb319ac003ac5ac09a47aec72755a91743d3954/duckdb-0.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06c1cef25f896b2284ba048108f645c72fab5c54aa5a6f62f95663f44ff8a79b"},
+    {url = "https://files.pythonhosted.org/packages/8a/54/4210ce0b26a010fd2755f8d78dcaeceeb4d1ddda76d2e884c0b130fae6dc/duckdb-0.6.1-cp311-cp311-win32.whl", hash = "sha256:e3702d4a9ade54c6403f6615a98bbec2020a76a60f5db7fcf085df1bd270e66e"},
+    {url = "https://files.pythonhosted.org/packages/8d/3d/2c5e19de3eb44213cb860d095e597eaa0e264ce34c918bb8a239b3b2c03d/duckdb-0.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:00b7be8f67ec1a8edaa8844f521267baa1a795f4c482bfad56c72c26e1862ab2"},
+    {url = "https://files.pythonhosted.org/packages/92/7c/5879a645e7a3abc13781c368a0ca550fe64e049f5c2e73b8d5834bb2a010/duckdb-0.6.1-cp39-cp39-win32.whl", hash = "sha256:d9212d76e90b8469743924a4d22bef845be310d0d193d54ae17d9ef1f753cfa7"},
+    {url = "https://files.pythonhosted.org/packages/94/68/c633dcd576dd63e627619a6274c17b6ddc8e2637fa9b037a5241b687c40b/duckdb-0.6.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e566514f9327f89264e98ac14ee7a84fbd9857328028258422c3e8375ee19d25"},
+    {url = "https://files.pythonhosted.org/packages/98/74/069f636ba410c7055847cd202bb8fb7e8ea1b0e0a2ae6b131ba40e0d4322/duckdb-0.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:998165b2fb1f1d2b0ad742096015ea70878f7d40304643c7424c3ed3ddf07bfc"},
+    {url = "https://files.pythonhosted.org/packages/9a/ce/39e5f2907cd4b7ae988a2b4a36c7c7d5cf6047e8e91299646a03cf5260da/duckdb-0.6.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:54b3da77ad893e99c073087ff7f75a8c98154ac5139d317149f12b74367211db"},
+    {url = "https://files.pythonhosted.org/packages/9f/98/42987cc5a2b64c217ce377c651c47510a3fab48752ea3706ec9580401976/duckdb-0.6.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8b544dd04bb851d08bc68b317a7683cec6091547ae75555d075f8c8a7edb626e"},
+    {url = "https://files.pythonhosted.org/packages/a2/02/a36ca6545c81cb6ec339fcff178b931b0079cdd9d39806da2d440dcdab32/duckdb-0.6.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3941b3a1e8a1cdb7b90ab3917b87af816e71f9692e5ada7f19b6b60969f731e5"},
+    {url = "https://files.pythonhosted.org/packages/b6/ae/ea1b6860227f0bb175d8a331a235c66a24883c746ee308a9391c5e697613/duckdb-0.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:99a7172563a3ae67d867572ce27cf3962f58e76f491cb7f602f08c2af39213b3"},
+    {url = "https://files.pythonhosted.org/packages/b9/ee/4016c31834123716532c97cb6a180f35ba90f63bfbae30a1af3a861b0929/duckdb-0.6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8442e074de6e1969c3d2b24363a5a6d7f866d5ac3f4e358e357495b389eff6c1"},
+    {url = "https://files.pythonhosted.org/packages/bc/1b/a0b13a6e985ff1024e0d52b372f43e385ce1538773ecac250e82543572e2/duckdb-0.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b64eb53d0d0695814bf1b65c0f91ab7ed66b515f89c88038f65ad5e0762571c"},
+    {url = "https://files.pythonhosted.org/packages/c3/a5/3a363fb6c1a7d3e35241ef66d69fc8a63f2110e3fdbf11f38ae0d0d5fa58/duckdb-0.6.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:adae183924d6d479202c39072e37d440b511326e84525bcb7432bca85f86caba"},
+    {url = "https://files.pythonhosted.org/packages/c5/ef/ff74822cbd8792138edad7da762fc1d371723761fe9362a44df85b09774c/duckdb-0.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b31c2883de5b19591a2852165e6b3f9821f77af649835f27bc146b26e4aa30cb"},
+    {url = "https://files.pythonhosted.org/packages/c9/76/e20ce03799d0734cef94cbaea7e501e3dd9931e352f096db285bbffd18df/duckdb-0.6.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0925778200090d3d5d8b6bb42b4d05d24db1e8912484ba3b7e7b7f8569f17dcb"},
+    {url = "https://files.pythonhosted.org/packages/de/b1/7f2ee1e567de4826f019c0aabec4aee9f1a876dbc837b4c27b783dfbff19/duckdb-0.6.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2c37d5a0391cf3a3a66e63215968ffb78e6b84f659529fa4bd10478f6203071"},
+    {url = "https://files.pythonhosted.org/packages/e6/2d/b43e5864efde07dce1d20a07cf2a238efb71878e002a14b0234da4a60936/duckdb-0.6.1-cp310-cp310-win32.whl", hash = "sha256:b39045074fb9a3f068496475a5d627ad4fa572fa3b4980e3b479c11d0b706f2d"},
+    {url = "https://files.pythonhosted.org/packages/e9/11/9072cfe234ca3b750e8d6a2b40147b8e2eff15382e398adda007f613829a/duckdb-0.6.1-cp38-cp38-win32.whl", hash = "sha256:bfe39ed3a03e8b1ed764f58f513b37b24afe110d245803a41655d16d391ad9f1"},
+    {url = "https://files.pythonhosted.org/packages/ef/a0/42dc092e852b3fc577445a53119d954d5b0c50815782b91a0cc66af4a1a1/duckdb-0.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c54910fbb6de0f21d562e18a5c91540c19876db61b862fc9ffc8e31be8b3f03"},
+    {url = "https://files.pythonhosted.org/packages/f5/5b/36689e4cacd753b68b2cac9a98496300be3d6eaf9fc4f93e4b4c38ad750b/duckdb-0.6.1-cp37-cp37m-win32.whl", hash = "sha256:f1d709aa6a26172a3eab804b57763d5cdc1a4b785ac1fc2b09568578e52032ee"},
+    {url = "https://files.pythonhosted.org/packages/ff/47/936e3be2d10c3b90346ef14eff4a076bb41974143202a086786fd8aa7328/duckdb-0.6.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a6bf2ae7bec803352dade14561cb0b461b2422e70f75d9f09b36ba2dad2613b"},
 ]
 "dynaconf 3.1.11" = [
     {url = "https://files.pythonhosted.org/packages/54/6f/09c3ca2943314e0cae5cb2eeca1b77f5968855e13d6fdaae32c8e055eb7c/dynaconf-3.1.11.tar.gz", hash = "sha256:d9cfb50fd4a71a543fd23845d4f585b620b6ff6d9d3cc1825c614f7b2097cb39"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ recap = "recap.cli:app"
 
 [project.entry-points."recap.analyzers"]
 "db.location" = "recap.analyzers.db.location"
+"duckdb.columns" = "recap.analyzers.duckdb.columns"
 "sqlalchemy.access" = "recap.analyzers.sqlalchemy.access"
 "sqlalchemy.columns" = "recap.analyzers.sqlalchemy.columns"
 "sqlalchemy.comment" = "recap.analyzers.sqlalchemy.comment"
@@ -74,6 +75,7 @@ serve = "recap.commands.serve:app"
 [project.optional-dependencies]
 fs = [
     "fsspec>=2023.1.0",
+    "duckdb>=0.6.1",
 ]
 
 [build-system]

--- a/recap/analyzers/duckdb/columns.py
+++ b/recap/analyzers/duckdb/columns.py
@@ -1,0 +1,64 @@
+import duckdb
+from contextlib import contextmanager
+from pathlib import PurePosixPath
+from recap.analyzers.abstract import AbstractAnalyzer, BaseMetadataModel
+from recap.browsers.fs import FilePath
+from typing import Generator, Literal
+from urllib.parse import urlparse
+
+
+SUPPORTED_SCHEMES = set(['', 'file', 'http', 'https', 's3'])
+
+
+class Column(BaseMetadataModel):
+    type: str
+    nullable: bool
+
+class Columns(BaseMetadataModel):
+    __root__: dict[str, Column] = {}
+
+
+class FileColumnAnalyzer(AbstractAnalyzer):
+    def __init__(self, url: str):
+        # DuckDB doesn't understand 'file://' prefix, so remove it.
+        self.url = url.removeprefix('file://')
+        self.db = duckdb.connect()
+
+    def analyze(
+        self,
+        path: FilePath,
+    ) -> Columns | None:
+        path_posix = PurePosixPath(str(path))
+        url_and_path = self.url + str(path_posix)
+        match path_posix.suffix:
+            case ('.csv' | '.tsv'):
+                self.db.execute(
+                    "DESCRIBE SELECT * FROM read_csv_auto(?)",
+                    [url_and_path],
+                )
+            case '.parquet':
+                self.db.execute(
+                    "DESCRIBE SELECT * FROM read_parquet(?)",
+                    [url_and_path],
+                )
+            case _:
+                return None
+        columns_dict = {}
+        for column_tuple in self.db.fetchall():
+            name = column_tuple[0]
+            type_ = column_tuple[1]
+            nullable = column_tuple[2] == 'YES'
+            columns_dict[name] = Column(type=type_, nullable=nullable)
+        return Columns.parse_obj(columns_dict)
+
+
+@contextmanager
+def create_analyzer(
+    url: str,
+    **_,
+) -> Generator['FileColumnAnalyzer', None, None]:
+    scheme = urlparse(url).scheme
+    if scheme in SUPPORTED_SCHEMES:
+        yield FileColumnAnalyzer(url)
+    else:
+        raise ValueError(f"Unsupported url={url}")

--- a/recap/browsers/analyzing.py
+++ b/recap/browsers/analyzing.py
@@ -153,10 +153,11 @@ def create_browser(**config) -> Generator['AnalyzingBrowser', None, None]:
                         exc_info=e,
                     )
 
-        log.warn(
-            "Found no metadata analyzers for url=%s. "
-            "Crawling will only create directories.",
-            url,
-        )
+        if not analyzers:
+            log.warn(
+                "Found no metadata analyzers for url=%s. "
+                "Crawling will only create directories.",
+                url,
+            )
 
         yield AnalyzingBrowser(browser, analyzers)


### PR DESCRIPTION
Recap can now get DuckDB-formatted schemas for CSV, TSV, and Parquet files on local, HTTP(S), or S3 filesystems.

Longer-term, I think frictionless data might be preferable since it supports more input sources. Still, I wanted to add DuckDB anyway because I want to use it for data profiling for these data types.

For JSON, I'm thinking of using GenSON to auto-generate JSON schemas for JSON files. I also opened a frictionless ticket, in the hopes that they might support JSON schema inference as well:

https://github.com/frictionlessdata/framework/issues/1405

I did experiment with DuckDB JSON schema parsing, but I found it to be inadequate. It does work:

```
SELECT json_group_structure(json)
FROM read_json_objects('some.json');
```

But the format is pretty clunky.

In short, remaining TODOs:

1. Add frictionless schema parsing for CSV, TSV, and Parquet.
2. Add Genson for JSON schemas
3. Add DuckDB data profiler (similar to `sqlalchemy/profile.py`)