### PR TITLE
Add a GenSON JSON schema analyzer for JSON files in local or remote f…

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -265,6 +265,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "genson"
+version = "1.2.2"
+summary = "GenSON is a powerful, user-friendly JSON Schema generator."
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 summary = "Copy your docs directly to the gh-pages branch."
@@ -1114,7 +1119,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:325c7149fe3e65b0631da6eb498998069da2ff1324853e2874edacf493f109dd"
+content_hash = "sha256:dcf9dc843016f689639c4e7565dd78c4db6ef5e1192288301f96cb241a813c90"
 
 [metadata.files]
 "aiobotocore 2.4.2" = [
@@ -1611,6 +1616,9 @@ content_hash = "sha256:325c7149fe3e65b0631da6eb498998069da2ff1324853e2874edacf49
 "gcsfs 2023.1.0" = [
     {url = "https://files.pythonhosted.org/packages/d7/6b/f5e347eda42ecfbe0a1d87f35a4d65c9a94bc90563f8df27735b4191ba3c/gcsfs-2023.1.0-py2.py3-none-any.whl", hash = "sha256:62c491b9e2a8e9e58b8a899eec2ce111f827718a65539019ff3cadf447e48f41"},
     {url = "https://files.pythonhosted.org/packages/df/ab/94922b9e53224229f51ac1ecf52b8f61399ad213692131eeed06dda10be1/gcsfs-2023.1.0.tar.gz", hash = "sha256:0a7b7ca8c1affa126a14ba35d7b7dff81c49e2aaceedda9732c7f159a4837a26"},
+]
+"genson 1.2.2" = [
+    {url = "https://files.pythonhosted.org/packages/e1/71/fbd2f1ad9695c92ad756b91f5a570f809c4959d3bd82266788cf222e5c5c/genson-1.2.2.tar.gz", hash = "sha256:8caf69aa10af7aee0e1a1351d1d06801f4696e005f06cedef438635384346a16"},
 ]
 "ghp-import 2.1.0" = [
     {url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ recap = "recap.cli:app"
 "db.location" = "recap.analyzers.db.location"
 "duckdb.columns" = "recap.analyzers.duckdb.columns"
 "frictionless.columns" = "recap.analyzers.frictionless.columns"
+"genson.columns" = "recap.analyzers.genson.columns"
 "sqlalchemy.access" = "recap.analyzers.sqlalchemy.access"
 "sqlalchemy.columns" = "recap.analyzers.sqlalchemy.columns"
 "sqlalchemy.comment" = "recap.analyzers.sqlalchemy.comment"
@@ -77,6 +78,7 @@ fs = [
     "fsspec>=2023.1.0",
     "duckdb>=0.6.1",
     "frictionless[parquet]>=5.5.1",
+    "genson>=1.2.2",
 ]
 
 [build-system]

--- a/recap/browsers/analyzing.py
+++ b/recap/browsers/analyzing.py
@@ -80,7 +80,7 @@ class AnalyzingBrowser(AbstractBrowser):
                     )
                     results |= {metadata.key(): metadata_dict}
             except Exception as e:
-                log.info(
+                log.debug(
                     'Unable to process path with analyzer path=%s analyzer=%s',
                     path,
                     analyzer.__class__.__name__,


### PR DESCRIPTION
…ilesystems

Recap can now generate JSON schemas for discovered JSON files in any filesystem that fsspec supports. JSON schemas are inferred using GenSON:

https://github.com/wolverdude/GenSON

JSON files are opened using fsspec's `open` method. I've verified that both local and Google Cloud Storage works (I don't have an AWS account).

I've added a `sample` param that defaults to 1024, so large files don't slow things down too much.

I had to eliminate `DirFileSystem` in `browsers/fs.py` because it was buggy when used with `gcsfs`. The `open` method was not able to open GCS files properly. The `browsers/fs.py` and `genson/columns.py` files now manage their own absolute and relative paths.