### PR TITLE
Fix `DatabaseCatalog.rm()` bug

### DIFF
--- a/recap/catalogs/db.py
+++ b/recap/catalogs/db.py
@@ -159,7 +159,7 @@ class DatabaseCatalog(AbstractCatalog):
         with self.Session() as session:
             session.execute(update(CatalogEntry).filter(
                 # parent = /foo/bar/baz
-                (CatalogEntry.parent == f"{path_posix}")
+                (CatalogEntry.parent == str(path_posix))
                 # or parent = /foo/bar/baz/%
                 | (CatalogEntry.parent.like(f"{path_posix}/%"))
                 # or parent = /foo/bar and name = baz
@@ -170,6 +170,11 @@ class DatabaseCatalog(AbstractCatalog):
             ).values(
                 deleted_at = func.now()
             ).execution_options(synchronize_session=False))
+
+            # Have to commit since synchronize_session=False. Have to set
+            # synchronize_session=False because BinaryExpression isn't
+            # supported in the filter otherwise.
+            session.commit()
 
     def ls(
         self,


### PR DESCRIPTION
Paths weren't being deleted as expected. It looks like the bug was caused by the `execution_options(synchronize_session=False))`. According to the docs:

>>>
False - don’t synchronize the session. This option is the most efficient and is reliable once the session is expired, which typically occurs after a commit(), or explicitly using expire_all(). Before the expiration, objects that were updated or deleted in the database may still remain in the session with stale values, which can lead to confusing results.
>>>

https://docs.sqlalchemy.org/en/14/orm/session_basics.html#selecting-a-synchronization-strategy

Since I wasn't committing, the deletion update was never written. Adding `session.commit()` seems to have fixed things.