### PR TITLE
Add Pandas `profile.py` analyzer for JSON, CSV/TSV, and Parquet

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:dcf9dc843016f689639c4e7565dd78c4db6ef5e1192288301f96cb241a813c90"
+content_hash = "sha256:f497e59310992121646b6a9ccb7a343beccecd8a6bdcef214214ee13649d2c0f"
 
 [metadata.files]
 "aiobotocore 2.4.2" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ recap = "recap.cli:app"
 "duckdb.columns" = "recap.analyzers.duckdb.columns"
 "frictionless.columns" = "recap.analyzers.frictionless.columns"
 "genson.columns" = "recap.analyzers.genson.columns"
+"pandas.profile" = "recap.analyzers.pandas.profile"
 "sqlalchemy.access" = "recap.analyzers.sqlalchemy.access"
 "sqlalchemy.columns" = "recap.analyzers.sqlalchemy.columns"
 "sqlalchemy.comment" = "recap.analyzers.sqlalchemy.comment"
@@ -79,6 +80,9 @@ fs = [
     "duckdb>=0.6.1",
     "frictionless[parquet]>=5.5.1",
     "genson>=1.2.2",
+]
+pandas = [
+    "pandas>=1.5.3",
 ]
 
 [build-system]

--- a/recap/analyzers/duckdb/columns.py
+++ b/recap/analyzers/duckdb/columns.py
@@ -56,7 +56,7 @@ class FileColumnAnalyzer(AbstractAnalyzer):
 def create_analyzer(
     url: str,
     **_,
-) -> Generator['FileColumnAnalyzer', None, None]:
+) -> Generator[FileColumnAnalyzer, None, None]:
     scheme = urlparse(url).scheme
     if scheme in SUPPORTED_SCHEMES:
         yield FileColumnAnalyzer(url)

--- a/recap/analyzers/frictionless/columns.py
+++ b/recap/analyzers/frictionless/columns.py
@@ -43,7 +43,7 @@ class FileColumnAnalyzer(AbstractAnalyzer):
 def create_analyzer(
     url: str,
     **_,
-) -> Generator['FileColumnAnalyzer', None, None]:
+) -> Generator[FileColumnAnalyzer, None, None]:
     scheme = urlparse(url).scheme
     if scheme in SUPPORTED_SCHEMES:
         if scheme == '':

--- a/recap/analyzers/genson/columns.py
+++ b/recap/analyzers/genson/columns.py
@@ -61,7 +61,7 @@ def create_analyzer(
     url: str,
     sample: int | None = 1024,
     **config,
-) -> Generator['FileColumnAnalyzer', None, None]:
+) -> Generator[FileColumnAnalyzer, None, None]:
     # TODO This is hacky. Shoulld factor out FS and patch creation.
     with create_browser(url=url, **config) as browser:
         yield FileColumnAnalyzer(browser.fs, browser.base_path, sample)

--- a/recap/analyzers/pandas/profile.py
+++ b/recap/analyzers/pandas/profile.py
@@ -1,0 +1,119 @@
+import logging
+import math
+import pandas
+from contextlib import contextmanager
+from datetime import datetime
+from json import dumps
+from pathlib import PurePosixPath
+from recap.analyzers.abstract import AbstractAnalyzer, BaseMetadataModel
+from recap.browsers.db import TablePath, ViewPath
+from recap.browsers.fs import FilePath
+from typing import Any, Generator
+
+
+log = logging.getLogger(__name__)
+
+
+class ColumnProfile(BaseMetadataModel):
+    count: int
+    unique: int | None = None
+    top: str | None = None
+    freq: int | None = None
+    mean: float | str | None = None
+    std: float | str | None = None
+    min: float | str | None = None
+    p25: float | str | None = None
+    p50: float | str | None = None
+    p75: float | str | None = None
+    p95: float | str | None = None
+    p99: float | str | None = None
+    p999: float | str | None = None
+    max: float | str | None = None
+
+
+class Profile(BaseMetadataModel):
+    __root__: dict[str, ColumnProfile] = {}
+
+
+class ProfileAnalyzer(AbstractAnalyzer):
+    def __init__(
+        self,
+        url: str,
+    ):
+        self.url = url
+
+    def analyze(
+        self,
+        path: TablePath | ViewPath | FilePath,
+    ) -> Profile | None:
+        path_posix = PurePosixPath(str(path))
+        url_and_path = self.url + str(path_posix)
+        df = pandas.DataFrame()
+        match (path, path_posix.suffix):
+            case (FilePath(), '.csv'):
+                df = pandas.read_csv(url_and_path)
+            case (FilePath(), '.tsv'):
+                df = pandas.read_csv(url_and_path, sep='\t')
+            case (FilePath(), '.json' | '.ndjson'):
+                df = pandas.read_json(url_and_path, lines=True)
+            case (FilePath(), '.parquet'):
+                df = pandas.read_parquet(url_and_path)
+            case (TablePath() | ViewPath(), _):
+                # Meh.. try a SQL connection, I guess.
+                # Types are pretty busted with structured matching. :(
+                name = path.table if isinstance(path, TablePath) else path.view # pyright: ignore [reportGeneralTypeIssues]
+                # TODO should sample the data here
+                df = pandas.read_sql_table(
+                    table_name=name,
+                    schema=path.schema_, # pyright: ignore [reportGeneralTypeIssues]
+                    con=self.url,
+                )
+        return self.analyze_dataframe(df) if not df.empty else None
+
+    def analyze_dataframe(self, df: pandas.DataFrame) -> Profile:
+        profile_dict = {}
+        df_description = df.describe(
+            percentiles=[.25, .5, .75, .95, .99, .999],
+            include='all',
+            # Get rid of FutureWarning
+            datetime_is_numeric=True,
+        )
+        # Get rid of 'nan' for JSON.
+        df_description = df_description.replace({math.nan: None})
+        for name, stats_dict in df_description.to_dict().items():
+            # Replace percentiles if they're set.
+            formatted_percentiles = {
+                'p25': stats_dict.pop('25%'),
+                'p50': stats_dict.pop('50%'),
+                'p75': stats_dict.pop('75%'),
+                'p95': stats_dict.pop('95%'),
+                'p99': stats_dict.pop('99%'),
+                'p999': stats_dict.pop('99.9%'),
+            } if '25%' in stats_dict else {}
+            column_profile_dict: dict[str, Any] = (
+                formatted_percentiles
+                | stats_dict
+            )
+            # Replace datetime with ISO 8601 for JSON.
+            column_profile_dict = dict([
+                (k, v.isoformat())
+                if isinstance(v, datetime)
+                else (k, v)
+                for k, v in column_profile_dict.items()
+            ])
+            # Pandas `top` can be a list or dict if input was JSON.
+            # Convert it to a JSON string.
+            if (
+                column_profile_dict['top'] is not None
+                and not isinstance(column_profile_dict['top'], str)
+            ):
+                column_profile_dict['top'] = dumps(column_profile_dict['top'])
+            # Finally! Create the ColumnProfile.
+            profile_dict[name] = ColumnProfile(**column_profile_dict)
+        return Profile.parse_obj(profile_dict)
+
+
+@contextmanager
+def create_analyzer(url: str, **_) -> Generator['ProfileAnalyzer', None, None]:
+    # TODO if URL is DB, create an engine that uses engine.* configs like db.py
+    yield ProfileAnalyzer(url)

--- a/recap/routers/catalog/typed.py
+++ b/recap/routers/catalog/typed.py
@@ -123,10 +123,9 @@ def add_routes(
         catalog: AbstractCatalog = Depends(get_catalog),
         **kwargs,
     ) -> metadata_class:
-        path = (
-            browser_root_path_class.template
-            + child_path_class.template
-        ).format(**kwargs)
+        browser_root_path = browser_root_path_class.parse_obj(kwargs)
+        child_path = child_path_class.parse_obj(kwargs)
+        path = str(browser_root_path) + str(child_path)
         metadata = catalog.read(path, time)
         if metadata:
             return metadata_class.parse_obj(metadata)
@@ -137,10 +136,9 @@ def add_routes(
         catalog: AbstractCatalog = Depends(get_catalog),
         **kwargs,
     ):
-        path = (
-            browser_root_path_class.template
-            + child_path_class.template
-        ).format(**kwargs)
+        browser_root_path = browser_root_path_class.parse_obj(kwargs)
+        child_path = child_path_class.parse_obj(kwargs)
+        path = str(browser_root_path) + str(child_path)
         metadata_dict = metadata.dict(
             by_alias=True,
             exclude_defaults=True,


### PR DESCRIPTION
JSON, CSV, TSV, and Parquet files now have a Pandas data profile analyzer for local filesystems, remote object stores (S3), and remote HTTP(S) locations. The profiler also runs against all SQLAlchemy compatible URLs, so `TablePath` and `ViewPath` locations are also analyzed with Pandas.

I also took the opportunity to fix a bug in the Frictionless, GenSON, and DuckDB columns.py analyzers, which were using forward reference types for their `create_analyzer` methods. Since these analyzers both had the same class name, the bug caused the plugins to all resolve to the first analyzer class that it saw. Thus, DuckDB's analyzer was returned for the Frictionless and GenSON analyzers as well.

Future work:

* And Pandas's `DataFrame.hist()` data to the profile.
* Add sampling support to the analyzer.