### PR TITLE
Fix `FilesystemBrowser` directory list bug

### DIFF
--- a/recap/browsers/fs.py
+++ b/recap/browsers/fs.py
@@ -116,7 +116,7 @@ def create_browser(
     # Don't use DirFileSystem because it doesn't work properly with gcsfs.
     yield FilesystemBrowser(
         fs=fs,
-        base_path=str(PurePosixPath('/', paths[0])),
+        base_path=paths[0],
         root_=FilesystemRootPath(
             scheme=default_root.scheme,
             name=name or default_root.name_,


### PR DESCRIPTION
Recap was improperly prefixing all FS paths with a `/` for its `base_path`. This was causing problems for nested directories with the `gcsfs` filesystem, which expects bucket paths to start with `bucket/path/to/some/file` rather than `/bucket/path/to/some/file`. I've verified that `gs://`, `file://`, and `/` filesystem URLs all work with nested sudirectories now.