### PR TITLE
Add README link to Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Recap makes it easy for engineers to build infrastructure and tools that need me
 * Supports major cloud data warehouses and Postgres
 * No external system dependencies required
 * Designed for the [CLI](https://docs.recap.cloud/latest/cli/)
-* Runs as a Python library or [REST API](https://docs.recap.cloud/latest/rest/)
+* Runs as a [Python API](https://docs.recap.cloud/latest/api/recap.analyzers/) or [REST API](https://docs.recap.cloud/latest/rest/)
 * Fully [pluggable](https://docs.recap.cloud/latest/guides/plugins/)
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Recap makes it easy for engineers to build infrastructure and tools that need me
 * Supports major cloud data warehouses and PostgreSQL
 * No external system dependencies required
 * Designed for the [CLI](cli.md)
-* Runs as a Python library or [REST API](rest.md)
+* Runs as a [Python API](api/recap.analyzers.md) or [REST API](rest.md)
 * Fully [pluggable](guides/plugins.md)
 
 ## Installation


### PR DESCRIPTION
Very minor update to point README and docs/index.md to the Python API. Since there's no index, I used the analyzers page.