### PR TITLE
Add BigQueryAccessAnalyzer for views, tables, and datasets

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "3.4.2"
+version = "3.5.0"
 requires_python = ">=3.7"
 summary = "Google BigQuery API client library"
 dependencies = [
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:d517995946c8fbeb8ef7d92327aef65257218ca4d5315a38fd370517af7e69d3"
+content_hash = "sha256:8bcb35f32ccd5d4ef8f75ae15bd85fab91f0ceefe7c62165ae95672707f225b0"
 
 [metadata.files]
 "aiobotocore 2.4.2" = [
@@ -1724,9 +1724,9 @@ content_hash = "sha256:d517995946c8fbeb8ef7d92327aef65257218ca4d5315a38fd370517a
     {url = "https://files.pythonhosted.org/packages/06/98/52a79d64ca8fd2e37eff8da6c78c26b2209f19d8ace8cafd1634453c4393/google-auth-oauthlib-0.8.0.tar.gz", hash = "sha256:81056a310fb1c4a3e5a7e1a443e1eb96593c6bbc55b26c0261e4d3295d3e6593"},
     {url = "https://files.pythonhosted.org/packages/98/0e/bfc3d7de5d1788871d1be3e6862fe3e56d92b446909b7b032c373fc4ecab/google_auth_oauthlib-0.8.0-py2.py3-none-any.whl", hash = "sha256:40cc612a13c3336d5433e94e2adb42a0c88f6feb6c55769e44500fc70043a576"},
 ]
-"google-cloud-bigquery 3.4.2" = [
-    {url = "https://files.pythonhosted.org/packages/07/09/36cf27994bd003589c336e39f3e263821f6eb6e338fe7878b2a16da89cdc/google_cloud_bigquery-3.4.2-py2.py3-none-any.whl", hash = "sha256:2d9f59f4e23cb796877ed89cb626013eae437457dc5b268b67072f3bdc6255cb"},
-    {url = "https://files.pythonhosted.org/packages/bd/fc/5eed4121d0b2d347b6dc25bc6b9250807611afba336f02c724c8a095f158/google-cloud-bigquery-3.4.2.tar.gz", hash = "sha256:224dc329bc5ad09d614db765c95f0bb8b24f0881b3d2a4854062ca346f8896f0"},
+"google-cloud-bigquery 3.5.0" = [
+    {url = "https://files.pythonhosted.org/packages/9a/24/3e3cab94189bbd15c5ba87600ebe124bdf049dbbc19963f91f68fa307bdf/google_cloud_bigquery-3.5.0-py2.py3-none-any.whl", hash = "sha256:358f54c473938b2d022335118b4e56cdcdaf22a5a112fa0cfeb888fd8814ba62"},
+    {url = "https://files.pythonhosted.org/packages/f9/8a/4d307594709535f17fdaf5750fa201bbaf723a6f820abcc10361ff2c1db3/google-cloud-bigquery-3.5.0.tar.gz", hash = "sha256:dd3ca84e5be6fa9e0570fb21665a902cc5651cbd045842fb714164c99a2639c4"},
 ]
 "google-cloud-bigquery-storage 2.18.0" = [
     {url = "https://files.pythonhosted.org/packages/70/6b/a15f0be0288524d19fe2ac4a99910991fc2e2a5f77a13395c28a57890c92/google-cloud-bigquery-storage-2.18.0.tar.gz", hash = "sha256:46772910f70d78265da5e7af4847939aed4bea6e2a64efe1b993c0c686b3af16"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ repository = "https://github.com/recap-cloud/recap"
 recap = "recap.cli:app"
 
 [project.entry-points."recap.analyzers"]
+"bigquery.access" = "recap.analyzers.bigquery.access"
 "db.location" = "recap.analyzers.db.location"
 "duckdb.columns" = "recap.analyzers.duckdb.columns"
 "frictionless.columns" = "recap.analyzers.frictionless.columns"
@@ -83,6 +84,11 @@ fs = [
 ]
 pandas = [
     "pandas>=1.5.3",
+]
+gcp = [
+    "google-cloud-bigquery>=3.5.0",
+    "gcsfs>=2023.1.0",
+    "sqlalchemy-bigquery>=1.5.0",
 ]
 
 [build-system]

--- a/recap/analyzers/bigquery/access.py
+++ b/recap/analyzers/bigquery/access.py
@@ -1,0 +1,115 @@
+from contextlib import contextmanager
+from google.cloud.bigquery import Client
+from recap.analyzers.abstract import AbstractAnalyzer, BaseMetadataModel
+from recap.browsers.db import SchemaPath, TablePath, ViewPath
+from typing import Generator
+from urllib.parse import urlparse
+
+
+class AccessEntry(BaseMetadataModel):
+    role: str
+    type: str
+    id: str
+
+
+class Access(BaseMetadataModel):
+    __root__: list[AccessEntry] = []
+
+
+class BigQueryAccessAnalyzer(AbstractAnalyzer):
+    """
+    Fetches table, view, and dataset access information from BigQuery.
+
+    BigQuery's Python client and access API are a mess. There are two entirely
+    different endpoints.
+
+    Tables use `get_iam_policy`, which returns a list of bindings like:
+
+        [{"role": "OWNER", members: ["user:user@email.com"]]
+
+    The dataset API is entirely different. The
+    `google.cloud.bigquery.dataset.AccessEntry`s you get are documented
+    [here](https://github.com/googleapis/python-bigquery/blob/bd1da9aa0a40b02b7d5409a0b094d8380e255c91/google/cloud/bigquery/dataset.py#L225).
+
+    BigQueryAccessAnalyzer does its best to map these disjoint structures into
+    a standard `recap.analyzers.bigquery.access.AccessEntry`.
+    """
+
+    def __init__(self, client: Client):
+        self.client = client
+
+    def analyze(
+        self,
+        path: SchemaPath | TablePath | ViewPath,
+    ) -> Access | None:
+        """
+        :param path: Fetch access information for a table, view, or dataset at
+            this path.
+        :returns: A list of `AccessEntry`s containint a role, id, and the type
+            (user, specialGroup, etc) of the id.
+        """
+
+        results = []
+        match path:
+            case TablePath() | ViewPath():
+                name = path.table if isinstance(path, TablePath) else path.view
+                table_id = f"{self.client.project}.{path.schema_}.{name}"
+                policy = self.client.get_iam_policy(table_id)
+                for binding in policy.bindings:
+                    role = binding['role']
+                    for member in binding['members']:
+                        type_, id = member.split(':')
+                        results.append(AccessEntry(
+                            role=role,
+                            type=type_,
+                            id=id,
+                        ))
+            case SchemaPath():
+                dataset = self.client.get_dataset(path.schema_)
+                for entry in dataset.access_entries:
+                    assert (
+                        entry.role
+                        and entry.entity_type
+                        and entry.entity_id
+                    )
+                    id = None
+                    match entry.entity_id:
+                        case str():
+                            id = entry.entity_id
+                        case {'projectId': str(), 'datasetId': str(), 'tableId': str()}:
+                            project_id = entry.entity_id['projectId']
+                            dataset_id = entry.entity_id['datasetId']
+                            table_id = entry.entity_id['tableId']
+                            id = f"`{project_id}`.`{dataset_id}`.`{table_id}`"
+                        case {'projectId': str(), 'datasetId': str(), 'routineId': str()}:
+                            project_id = entry.entity_id['projectId']
+                            dataset_id = entry.entity_id['datasetId']
+                            routine_id = entry.entity_id['routineId']
+                            id = f"`{project_id}`.`{dataset_id}`.`{routine_id}`"
+                        case {'dataset': _, 'target_types': str()}:
+                            project_id = entry.entity_id['dataset']['projectId']
+                            dataset_id = entry.entity_id['dataset']['datasetId']
+                            target_types = entry.entity_id['target_types']
+                            id = f"`{project_id}`.`{dataset_id}`.`{target_types}`"
+                        case _:
+                            raise ValueError(
+                                f"Couldn't parse AccessEntry={entry}"
+                            )
+                    results.append(AccessEntry(
+                        role=entry.role,
+                        type=entry.entity_type,
+                        id=id,
+                    ))
+        return Access.parse_obj(results)
+
+
+@contextmanager
+def create_analyzer(
+    url: str,
+    **_,
+) -> Generator['BigQueryAccessAnalyzer', None, None]:
+    parsed_url = urlparse(url)
+
+    yield BigQueryAccessAnalyzer(Client(
+        project=parsed_url.hostname,
+    ))

--- a/recap/crawler.py
+++ b/recap/crawler.py
@@ -48,6 +48,7 @@ class Crawler:
         catalog: AbstractCatalog,
         recursive: bool = True,
         filters: list[str] = [],
+        **_,
     ):
         """
         :param browser: AnalyzingBrowser to use for listing children and


### PR DESCRIPTION
Recap now gets BigQuery access information for views, tables, and datasets.

This analyzer is more complex that it should be, but BigQuery's access API is a mess. They've just introduced table-level access controls, which go through the `get_iam_policy` API rather than the `dataset.access_entries` attribute. BigQueryAccessAnalyzer munges these two data structures into a standard-ish format called `AccessEntry`. See the docs on the analyzer for more information.

And here's some documentation on Google's AccessEntry class for datasets (which is different from Recap's).

https://github.com/googleapis/python-bigquery/blob/bd1da9aa0a40b02b7d5409a0b094d8380e255c91/google/cloud/bigquery/dataset.py#L225

I also explored using `information_schema.object_privileges`, but it seems less efficient (and I think it costs $ to use). Here are some docs on that approach:

https://cloud.google.com/bigquery/docs/information-schema-object-privileges

And an example query:

```
SELECT *
FROM `some-project-1234`.`region-us`.INFORMATION_SCHEMA.OBJECT_PRIVILEGES
WHERE object_name='austin_311'
```

And here are some docs on getting (and granting) access to a "resource" (dataset, table, or view):

https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#python

NOTE: I didn't bother with routines or external sources for now.