### PR TITLE
Add job counts and latest queries analyzers for BigQuery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ recap = "recap.cli:app"
 
 [project.entry-points."recap.analyzers"]
 "bigquery.access" = "recap.analyzers.bigquery.access"
+"bigquery.latest_queries" = "recap.analyzers.bigquery.latest_queries"
+"bigquery.job_counts" = "recap.analyzers.bigquery.job_counts"
 "db.location" = "recap.analyzers.db.location"
 "duckdb.columns" = "recap.analyzers.duckdb.columns"
 "frictionless.columns" = "recap.analyzers.frictionless.columns"

--- a/recap/analyzers/bigquery/access.py
+++ b/recap/analyzers/bigquery/access.py
@@ -109,7 +109,6 @@ def create_analyzer(
     **_,
 ) -> Generator['BigQueryAccessAnalyzer', None, None]:
     parsed_url = urlparse(url)
-
-    yield BigQueryAccessAnalyzer(Client(
-        project=parsed_url.hostname,
-    ))
+    client = Client(project=parsed_url.hostname)
+    yield BigQueryAccessAnalyzer(client)
+    client.close()

--- a/recap/analyzers/bigquery/job_counts.py
+++ b/recap/analyzers/bigquery/job_counts.py
@@ -1,0 +1,130 @@
+from contextlib import contextmanager
+from google.cloud.bigquery import Client, QueryJobConfig, ScalarQueryParameter
+from recap.analyzers.abstract import AbstractAnalyzer, BaseMetadataModel
+from recap.browsers.db import TablePath, ViewPath
+from typing import Generator
+from urllib.parse import urlparse
+
+
+class QueryCount(BaseMetadataModel):
+    query_count: int
+    total_bytes_processed: int
+    total_slot_ms: int
+    first_job_time: str
+    last_job_time: str
+
+
+class User(BaseMetadataModel):
+    __root__: dict[str, QueryCount]
+
+
+class QueryCounts(BaseMetadataModel):
+    __root__: dict[str, User] = {}
+
+
+class BigQueryJobCountAnalyzer(AbstractAnalyzer):
+    """
+    Computes which users have been using a table, and how many jobs (QUERY,
+    LOAD, EXTRACT, COPY) they've executed. Also provides the first and last job
+    time for each user.
+
+    NOTE: The bytes processed and slot milliseconds statistics include bytes
+    and slots for all tables touched in a job. For example, the
+    total_bytes_processed a QUERY job that joins two tables will include the
+    bytes processed from both input tables.
+    """
+
+    def __init__(
+        self,
+        client: Client,
+        days: int = 30,
+        limit: int = 1000,
+        region: str = 'region-us',
+        **_,
+    ):
+        """
+        :param client: BigQuery Client to use when querying.
+        :param days: How far back to analyze.
+        :param limit: Maximum number of rows to return. If limit is set, some
+            users might contain only some job types since other job types might
+            fall below the limit.
+        :param region: The region to query. INFORMATION_SCHEMA.JOBS_BY_USER
+            requires this.
+        """
+
+        self.client = client
+        self.days = days
+        self.limit = limit
+        self.region = region
+
+    def analyze(
+        self,
+        path: TablePath | ViewPath,
+    ) -> QueryCounts | None:
+        """
+        :param path: The path to analyze for job counts.
+        :returns: Query counts for each user, aggregated by job_type.
+        """
+
+        users = {}
+        name = path.table if isinstance(path, TablePath) else path.view
+
+        # .format variables
+        project_id = self.client.project
+        region = self.region
+
+        # param variables
+        job_config = QueryJobConfig(
+            query_parameters = [
+                ScalarQueryParameter("project_id", "STRING", self.client.project),
+                ScalarQueryParameter("dataset_id", "STRING", path.schema_),
+                ScalarQueryParameter("table_id", "STRING", name),
+                ScalarQueryParameter("days", "INT64", self.days),
+                ScalarQueryParameter("limit_", "INT64", self.limit),
+            ],
+        )
+
+        sql = f"""
+            SELECT
+                user_email,
+                job_type,
+                COUNT(*) as query_count,
+                SUM(total_bytes_processed) as total_bytes_processed,
+                SUM(total_slot_ms) as total_slot_ms,
+                -- For JSON. Uses ISO 8601.
+                CAST(MIN(start_time) AS STRING) as first_job_time,
+                CAST(MAX(start_time) AS STRING) AS last_job_time,
+            FROM
+                `{project_id}`.`{region}`.INFORMATION_SCHEMA.JOBS_BY_USER,
+                UNNEST(referenced_tables) referenced_table
+            WHERE
+                referenced_table.project_id = @project_id AND
+                referenced_table.dataset_id = @dataset_id AND
+                referenced_table.table_id = @table_id AND
+                -- A NULL value indicates an internal job, such as a script job
+                -- statement evaluation or a materialized view refresh. Ignore.
+                job_type IS NOT NULL AND
+                state = 'DONE' AND
+                creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+            GROUP BY 1, 2
+            ORDER BY 3 DESC
+            LIMIT @limit_
+        """
+        results = self.client.query(sql, job_config=job_config).result()
+
+        for row in results:
+            user = users.get(row.user_email, {})
+            user[row.job_type] = dict(row)
+            users[row.user_email] = user
+
+        return QueryCounts.parse_obj(users)
+
+@contextmanager
+def create_analyzer(
+    url: str,
+    **configs,
+) -> Generator['BigQueryJobCountAnalyzer', None, None]:
+    parsed_url = urlparse(url)
+    client = Client(project=parsed_url.hostname)
+    yield BigQueryJobCountAnalyzer(client, **configs)
+    client.close()

--- a/recap/analyzers/bigquery/latest_queries.py
+++ b/recap/analyzers/bigquery/latest_queries.py
@@ -1,0 +1,135 @@
+from contextlib import contextmanager
+from google.cloud.bigquery import Client, QueryJobConfig, ScalarQueryParameter
+from recap.analyzers.abstract import AbstractAnalyzer, BaseMetadataModel
+from recap.browsers.db import TablePath, ViewPath
+from typing import Generator
+from urllib.parse import urlparse
+
+
+class QueryJobError(BaseMetadataModel):
+    reason: str | None
+    message: str | None
+
+
+class QueryJob(BaseMetadataModel):
+    job_id: str
+    query: str
+    statement_type: str
+    user_email: str
+    start_time: str
+    end_time: str
+    priority: str
+    total_bytes_processed: int | None
+    total_slot_ms: int | None
+    error: QueryJobError | None
+
+
+class QueryJobs(BaseMetadataModel):
+    __root__: list[QueryJob] = []
+
+
+class BigQueryLatestQueriesAnalyzer(AbstractAnalyzer):
+    """
+    Retrieves the most recent queries on a table or view.
+
+    NOTE: The bytes processed and slot milliseconds statistics include bytes
+    and slots for all tables touched in a job. For example, the
+    total_bytes_processed a QUERY job that joins two tables will include the
+    bytes processed from both input tables.
+    """
+
+    def __init__(
+        self,
+        client: Client,
+        days: int = 30,
+        limit: int = 1000,
+        region: str = 'region-us',
+        **_,
+    ):
+        """
+        :param client: BigQuery Client to use when querying.
+        :param days: How far back to analyze.
+        :param limit: Maximum number of rows to return.
+        :param region: The region to query. INFORMATION_SCHEMA.JOBS_BY_USER
+            requires this.
+        """
+
+        self.client = client
+        self.days = days
+        self.limit = limit
+        self.region = region
+
+    def analyze(
+        self,
+        path: TablePath | ViewPath,
+    ) -> QueryJobs | None:
+        """
+        :param path: The path to gather queries for.
+        :returns: Most recent queries. Includes the query, the user, and
+            various statistics about the query.
+        """
+
+        jobs = []
+        name = path.table if isinstance(path, TablePath) else path.view
+
+        # .format variables
+        project_id = self.client.project
+        region = self.region
+
+        # param variables
+        job_config = QueryJobConfig(
+            query_parameters = [
+                ScalarQueryParameter("project_id", "STRING", self.client.project),
+                ScalarQueryParameter("dataset_id", "STRING", path.schema_),
+                ScalarQueryParameter("table_id", "STRING", name),
+                ScalarQueryParameter("days", "INT64", self.days),
+                ScalarQueryParameter("limit_", "INT64", self.limit),
+            ],
+        )
+
+        sql = f"""
+            SELECT
+                job_id,
+                query,
+                state,
+                user_email,
+                -- For JSON. Uses ISO 8601.
+                CAST(start_time AS STRING) start_time,
+                CAST(end_time AS STRING) end_time,
+                priority,
+                total_bytes_processed,
+                total_slot_ms,
+                error_result,
+                statement_type,
+            FROM
+                `{project_id}`.`{region}`.INFORMATION_SCHEMA.JOBS_BY_USER,
+                UNNEST(referenced_tables) referenced_table
+            WHERE
+                referenced_table.project_id = @project_id AND
+                referenced_table.dataset_id = @dataset_id AND
+                referenced_table.table_id = @table_id AND
+                state = 'DONE' AND
+                job_type = 'QUERY' AND
+                creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+            ORDER BY creation_time DESC
+            LIMIT @limit_
+        """
+        results = self.client.query(sql, job_config=job_config).result()
+
+        for row in results:
+            row_dict = dict(row)
+            if error_result := row_dict.get('error_result'):
+                row_dict['error'] = QueryJobError.parse_obj(dict(error_result)) # pyright: ignore [reportGeneralTypeIssues]
+            jobs.append(QueryJob.parse_obj(dict(row_dict)))
+
+        return QueryJobs.parse_obj(jobs)
+
+@contextmanager
+def create_analyzer(
+    url: str,
+    **configs,
+) -> Generator['BigQueryLatestQueriesAnalyzer', None, None]:
+    parsed_url = urlparse(url)
+    client = Client(project=parsed_url.hostname)
+    yield BigQueryLatestQueriesAnalyzer(client, **configs)
+    client.close()


### PR DESCRIPTION
Recap now analyzes BigQuery tables and views for job counts per-user and latest queries executed on the resource. This data is really useful for administrators and administrators trying to get usage info. It's also useful for discovery, since users need to know who is most likely to understand a table.