### PR TITLE
Cache BigQuery job counts in BigQueryJobCountAnalyzer

### DIFF
--- a/recap/analyzers/bigquery/access.py
+++ b/recap/analyzers/bigquery/access.py
@@ -15,7 +15,7 @@ class AccessEntry(BaseMetadataModel):
 
 
 class Access(BaseMetadataModel):
-    __root__: list[AccessEntry] = []
+    __root__: list[AccessEntry]
 
 
 class BigQueryAccessAnalyzer(AbstractAnalyzer):

--- a/recap/analyzers/bigquery/job_counts.py
+++ b/recap/analyzers/bigquery/job_counts.py
@@ -8,8 +8,8 @@ from recap.analyzers.abstract import AbstractAnalyzer, BaseMetadataModel
 from recap.browsers.db import TablePath, ViewPath
 
 
-class QueryCount(BaseMetadataModel):
-    query_count: int
+class JobCount(BaseMetadataModel):
+    job_count: int
     total_bytes_processed: int
     total_slot_ms: int
     first_job_time: str
@@ -17,18 +17,25 @@ class QueryCount(BaseMetadataModel):
 
 
 class User(BaseMetadataModel):
-    __root__: dict[str, QueryCount]
+    __root__: dict[str, JobCount]
 
 
-class QueryCounts(BaseMetadataModel):
+class JobCounts(BaseMetadataModel):
     __root__: dict[str, User] = {}
 
 
 class BigQueryJobCountAnalyzer(AbstractAnalyzer):
     """
     Computes which users have been using a table, and how many jobs (QUERY,
-    LOAD, EXTRACT, COPY) they've executed. Also provides the first and last job
+    LOAD, EXTRACT, COPY) they've executed. Also, gets the first and last job
     time for each user.
+
+    This analyzer caches results by region so as not to query the same
+    jobs_by_user table over and over again for each dataset/table. Every time a
+    dataset from a new region is encountered, the job stats for the entire
+    region are calculated using a BigQuery INFORMATION_SCHEMA query. The
+    results are cached in-memory for future use with datasets and in the same
+    region.
 
     NOTE: The bytes processed and slot milliseconds statistics include bytes
     and slots for all tables touched in a job. For example, the
@@ -40,86 +47,112 @@ class BigQueryJobCountAnalyzer(AbstractAnalyzer):
         self,
         client: Client,
         days: int = 30,
-        limit: int = 1000,
         region: str = "region-us",
         **_,
     ):
         """
         :param client: BigQuery Client to use when querying.
         :param days: How far back to analyze.
-        :param limit: Maximum number of rows to return. If limit is set, some
-            users might contain only some job types since other job types might
-            fall below the limit.
         :param region: The region to query. INFORMATION_SCHEMA.JOBS_BY_USER
             requires this.
         """
 
         self.client = client
         self.days = days
-        self.limit = limit
         self.region = region
+        # dict[region, dict[dataset, dict[table, dict[user_email, User]]]]
+        self.region_cache: dict[str, dict[str, dict[str, dict[str, User]]]] = {}
 
-    def analyze(
-        self,
-        path: TablePath | ViewPath,
-    ) -> QueryCounts | None:
-        """
-        :param path: The path to analyze for job counts.
-        :returns: Query counts for each user, aggregated by job_type.
-        """
+    def _load_region_cache(self, region: str):
+        if self.region_cache.get(region) is not None:
+            # Skip if we've already cache this region.
+            return
 
-        users = {}
-        name = path.table if isinstance(path, TablePath) else path.view
+        region_cache = {}
 
-        # .format variables
+        # .format variables. BQ doesn't allow @ variables in table names.
+        # TODO: This is an injection attack vulnerability.
         project_id = self.client.project
-        region = self.region
 
         # param variables
         job_config = QueryJobConfig(
             query_parameters=[
                 ScalarQueryParameter("project_id", "STRING", self.client.project),
-                ScalarQueryParameter("dataset_id", "STRING", path.schema_),
-                ScalarQueryParameter("table_id", "STRING", name),
                 ScalarQueryParameter("days", "INT64", self.days),
-                ScalarQueryParameter("limit_", "INT64", self.limit),
             ],
         )
 
         sql = f"""
             SELECT
+                dataset_id,
+                table_id,
                 user_email,
-                job_type,
-                COUNT(*) as query_count,
-                SUM(total_bytes_processed) as total_bytes_processed,
-                SUM(total_slot_ms) as total_slot_ms,
-                -- For JSON. Uses ISO 8601.
-                CAST(MIN(start_time) AS STRING) as first_job_time,
-                CAST(MAX(start_time) AS STRING) AS last_job_time,
-            FROM
-                `{project_id}`.`{region}`.INFORMATION_SCHEMA.JOBS_BY_USER,
-                UNNEST(referenced_tables) referenced_table
-            WHERE
-                referenced_table.project_id = @project_id AND
-                referenced_table.dataset_id = @dataset_id AND
-                referenced_table.table_id = @table_id AND
-                -- A NULL value indicates an internal job, such as a script job
-                -- statement evaluation or a materialized view refresh. Ignore.
-                job_type IS NOT NULL AND
-                state = 'DONE' AND
-                creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
-            GROUP BY 1, 2
-            ORDER BY 3 DESC
-            LIMIT @limit_
+                ARRAY_AGG(STRUCT(
+                    job_type,
+                    job_count,
+                    total_bytes_processed,
+                    total_slot_ms,
+                    first_job_time,
+                    last_job_time
+                )) job_counts,
+            FROM (
+                SELECT
+                    referenced_table.dataset_id,
+                    referenced_table.table_id,
+                    user_email,
+                    job_type,
+                    COUNT(*) as job_count,
+                    SUM(total_bytes_processed) as total_bytes_processed,
+                    SUM(total_slot_ms) as total_slot_ms,
+                    -- For JSON. Uses ISO 8601.
+                    CAST(MIN(start_time) AS STRING) as first_job_time,
+                    CAST(MAX(start_time) AS STRING) AS last_job_time,
+                FROM
+                    `{project_id}`.`region-{region}`.INFORMATION_SCHEMA.JOBS_BY_USER,
+                    UNNEST(referenced_tables) referenced_table
+                WHERE
+                    referenced_table.project_id = @project_id AND
+                    -- A NULL value indicates an internal job, such as a script job
+                    -- statement evaluation or a materialized view refresh. Ignore.
+                    job_type IS NOT NULL AND
+                    state = 'DONE' AND
+                    creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+                GROUP BY 1, 2,3 ,4
+            ) GROUP BY 1, 2, 3;
         """
+
         results = self.client.query(sql, job_config=job_config).result()
 
         for row in results:
-            user = users.get(row.user_email, {})
-            user[row.job_type] = dict(row)
-            users[row.user_email] = user
+            dataset_cache = region_cache.setdefault(row.dataset_id, {})
+            table_cache = dataset_cache.setdefault(row.table_id, {})
+            user_counts = {}
+            for job_counts in row.job_counts:
+                user_counts[job_counts["job_type"]] = JobCount.parse_obj(job_counts)
+            table_cache[row.user_email] = User.parse_obj(user_counts)
 
-        return QueryCounts.parse_obj(users)
+        self.region_cache[region] = region_cache
+
+    def analyze(
+        self,
+        path: TablePath | ViewPath,
+    ) -> JobCounts | None:
+        """
+        :param path: The path to analyze for job counts.
+        :returns: Query counts for each user, aggregated by job_type.
+        """
+
+        dataset_name = path.schema_
+        dataset = self.client.get_dataset(dataset_name)
+        region_name = dataset.location
+        table_name = path.table if isinstance(path, TablePath) else path.view
+        if region_name:
+            self._load_region_cache(region_name)
+            region_counts = self.region_cache.get(region_name, {})
+            dataset_counts = region_counts.get(dataset_name, {})
+            if job_counts := dataset_counts.get(table_name):
+                return JobCounts.parse_obj(job_counts)
+        return None
 
 
 @contextmanager

--- a/recap/analyzers/bigquery/latest_queries.py
+++ b/recap/analyzers/bigquery/latest_queries.py
@@ -27,7 +27,7 @@ class QueryJob(BaseMetadataModel):
 
 
 class QueryJobs(BaseMetadataModel):
-    __root__: list[QueryJob] = []
+    __root__: list[QueryJob]
 
 
 class BigQueryLatestQueriesAnalyzer(AbstractAnalyzer):
@@ -121,9 +121,9 @@ class BigQueryLatestQueriesAnalyzer(AbstractAnalyzer):
         for row in results:
             row_dict = dict(row)
             if error_result := row_dict.get("error_result"):
-                row_dict["error"] = QueryJobError.parse_obj(
-                    dict(error_result)
-                )  # pyright: ignore [reportGeneralTypeIssues]
+                row_dict["error"] = QueryJobError.parse_obj(  # type: ignore
+                    dict(error_result)  # type: ignore
+                )
             jobs.append(QueryJob.parse_obj(dict(row_dict)))
 
         return QueryJobs.parse_obj(jobs)

--- a/recap/browsers/analyzing.py
+++ b/recap/browsers/analyzing.py
@@ -74,8 +74,8 @@ class AnalyzingBrowser(AbstractBrowser):
                     )
                     # Have to unpack __root__ if it exists, sigh.
                     # https://github.com/pydantic/pydantic/issues/1193
-                    metadata_dict = metadata_dict.get("__root__", metadata_dict)
-                    results |= {metadata.key(): metadata_dict}
+                    metadata_obj = metadata_dict.get("__root__", metadata_dict)
+                    results |= {metadata.key(): metadata_obj}
             except Exception as e:
                 log.debug(
                     "Unable to process path with analyzer path=%s analyzer=%s",


### PR DESCRIPTION
The job count analyzer was querying the INFORMATION_SCHEMA.JOBS_BY_USER every time a new table was encountered. This was inefficient and potentially costly. I've added logic to query each region once, and cache all table counts for each dataset in the region. This speeds things up and drops costs. It does mean the analyzer now stores all job counts for all tables in memory, which could potentially be a lot of memory if a region has a ton of tables.

I also fixed a bug that was causing unprocessable entity errors. Turns out that empty access/query lists were being `.dict()`'d to `{}` if they were empty (rather than `{"__root__":[]})`. This was breaking verification. I removed the defaults, which seems to have fixed the problem.