### PR TITLE
Exclude Google imports if the dependency is missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "recap-core"
-version = "0.5.0"
+version = "0.5.1"
 description = "A metadata toolkit written in Python"
 authors = [
     {name = "Chris Riccomini", email = "criccomini@apache.org"},

--- a/recap/integrations/__init__.py
+++ b/recap/integrations/__init__.py
@@ -1,4 +1,9 @@
 # Load all integrations into the registry
-import recap.integrations.bigquery
+
+try:
+    import recap.integrations.bigquery
+except:
+    # Skip Google if dependencies aren't installed.
+    pass
 import recap.integrations.fsspec
 import recap.integrations.sqlalchemy


### PR DESCRIPTION
`recap.integrations` was trying to import the Google integrations no matter what. This caused a `No module named...` exception to be thrown. Catching this and skipping Google if the dependencies aren't installed.