### PR TITLE
Add `metadata.Schema` conversion for common serialization types

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -290,6 +290,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "genson"
+version = "1.2.2"
+summary = "GenSON is a powerful, user-friendly JSON Schema generator."
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 summary = "Copy your docs directly to the gh-pages branch."
@@ -1174,6 +1179,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlglot"
+version = "11.2.3"
+summary = "An easily customizable SQL parser and transpiler"
+
+[[package]]
 name = "starlette"
 version = "0.22.0"
 requires_python = ">=3.7"
@@ -1330,7 +1340,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:0d2e2c048e9fecc9ac8366bb4c39fba26ddaa156338f980372da92104e44cd91"
+content_hash = "sha256:696ac871deb3931a84edf2bdcc24a3fd34dd7afdf36160397a6e27034a2624af"
 
 [metadata.files]
 "aiobotocore 2.4.2" = [
@@ -1813,6 +1823,9 @@ content_hash = "sha256:0d2e2c048e9fecc9ac8366bb4c39fba26ddaa156338f980372da92104
 "gcsfs 2023.1.0" = [
     {url = "https://files.pythonhosted.org/packages/d7/6b/f5e347eda42ecfbe0a1d87f35a4d65c9a94bc90563f8df27735b4191ba3c/gcsfs-2023.1.0-py2.py3-none-any.whl", hash = "sha256:62c491b9e2a8e9e58b8a899eec2ce111f827718a65539019ff3cadf447e48f41"},
     {url = "https://files.pythonhosted.org/packages/df/ab/94922b9e53224229f51ac1ecf52b8f61399ad213692131eeed06dda10be1/gcsfs-2023.1.0.tar.gz", hash = "sha256:0a7b7ca8c1affa126a14ba35d7b7dff81c49e2aaceedda9732c7f159a4837a26"},
+]
+"genson 1.2.2" = [
+    {url = "https://files.pythonhosted.org/packages/e1/71/fbd2f1ad9695c92ad756b91f5a570f809c4959d3bd82266788cf222e5c5c/genson-1.2.2.tar.gz", hash = "sha256:8caf69aa10af7aee0e1a1351d1d06801f4696e005f06cedef438635384346a16"},
 ]
 "ghp-import 2.1.0" = [
     {url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
@@ -3007,6 +3020,10 @@ content_hash = "sha256:0d2e2c048e9fecc9ac8366bb4c39fba26ddaa156338f980372da92104
 "sqlalchemy-bigquery 1.6.1" = [
     {url = "https://files.pythonhosted.org/packages/21/0d/dfb74d4d55c24fd5805b624359d6b0a8f8b9a27fbe59b6d1260d5d5d4ec1/sqlalchemy-bigquery-1.6.1.tar.gz", hash = "sha256:352fe5e1d2a9d2991a88c501a97624912e4b59b4b5c0d6a98c63b7228f37ea4e"},
     {url = "https://files.pythonhosted.org/packages/63/13/691bdb7c0eecc2a848cc34882baf485331d86fe9bb37a9f57a66eca80e8b/sqlalchemy_bigquery-1.6.1-py2.py3-none-any.whl", hash = "sha256:e9ce790d5172fbcc867b4fc92ec5047ad5e906e0121691907aab86e8a69adb65"},
+]
+"sqlglot 11.2.3" = [
+    {url = "https://files.pythonhosted.org/packages/64/54/ca862d8a8489db770929545d050c1c376f4bf356d3fe7a725b42b9524402/sqlglot-11.2.3.tar.gz", hash = "sha256:1d07e05536123471545f751d961927b3476e063e71e7c22f138cec9d540a57e2"},
+    {url = "https://files.pythonhosted.org/packages/83/99/f0519b3bb5429fd687faa214eab11379d2561a4036e445527ef2d9adf828/sqlglot-11.2.3-py3-none-any.whl", hash = "sha256:1633d81d22ba34e328b583e569aef67ea4dbcdea6f8853350f7f594364a34bd8"},
 ]
 "starlette 0.22.0" = [
     {url = "https://files.pythonhosted.org/packages/1d/4e/30eda84159d5b3ad7fe663c40c49b16dd17436abe838f10a56c34bee44e8/starlette-0.22.0-py3-none-any.whl", hash = "sha256:b5eda991ad5f0ee5d8ce4c4540202a573bb6691ecd0c712262d0bc85cf8f2c50"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "fsspec>=2023.1.0",
     "frictionless[json,parquet]>=5.6.3",
     "tomli>=2.0.1",
+    "genson>=1.2.2",
+    "sqlglot>=11.2.3",
 ]
 # < 3.11 for sqlalchemy-bigquery compatibility
 requires-python = ">=3.10, <3.11"

--- a/recap/integrations/sqlalchemy.py
+++ b/recap/integrations/sqlalchemy.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 from sqlalchemy import inspect
 from sqlalchemy.engine import Engine
 
-from recap.metadata import Field, Schema
+from recap.metadata import Schema
 from recap.registry import registry
+from recap.schema.sqlalchemy import to_recap_schema
 
 
 @registry.metadata(
@@ -44,18 +45,7 @@ def schema(
         table,
         schema,
     )
-    return Schema(
-        fields=[
-            Field(
-                name=column["name"],
-                type=str(column["type"]),
-                default=column["default"],
-                nullable=column["nullable"],
-                comment=column.get("comment"),
-            )
-            for column in columns
-        ],
-    )
+    return to_recap_schema(columns)
 
 
 @registry.relationship(

--- a/recap/metadata.py
+++ b/recap/metadata.py
@@ -8,33 +8,21 @@ accounts and jobs, are represented by URLs, but have no associated metadata.
 
 from __future__ import annotations
 
+from typing import Any, ClassVar
+
 from pydantic import BaseModel
+from pydantic import Field as PydanticField
 
 
 class Field(BaseModel):
-    name: str
+    schema_: Schema = PydanticField(alias="schema")
     """
-    The name of a field.
-    """
-
-    type: str | None = None
-    """
-    A field's type.
+    A field's schema
     """
 
-    default: str | None = None
+    name: str | None = None
     """
-    A field's default value (represented as a string).
-    """
-
-    nullable: bool | None = None
-    """
-    Whether the field is nullable or not. If `False`, the field is required.
-    """
-
-    comment: str | None = None
-    """
-    A documentation comment for the field.
+    A field's name.
     """
 
 
@@ -43,7 +31,164 @@ class Schema(BaseModel):
     Recap's representation of a Schema.
     """
 
+    # TODO This should be ClassVar, but Pydantic doesn't seem to want to
+    # seralize ClassVars with Python 3.10.
+    type_: str = PydanticField(alias="type", const=True)
+    """
+    The schema's type.
+    """
+
+    default: Any = None
+    """
+    :returns: Default value for the schema.
+    """
+
+    name: str | None = None
+    """
+    The schema's name.
+    """
+
+    optional: bool = True
+    """
+    :returns: True if the schema is optional.
+    """
+
+    version: int | None = None
+    """
+    Optional schema version. Newer versions must be larger than older versions.
+    """
+
+    doc: str | None = None
+    """
+    A schema's documentation.
+    """
+
+    parameters: dict[str, str] | None = None
+    """
+    A map of optional schema parameters.
+    """
+
+    def is_primitive(self) -> bool:
+        match self.type_:
+            case (
+                "STRING"
+                | "INT8"
+                | "INT16"
+                | "INT32"
+                | "INT64"
+                | "FLOAT32"
+                | "FLOAT64"
+                | "BOOLEAN"
+                | "BYTES"
+            ):
+                return True
+        return False
+
+    def __str__(self) -> str:
+        return self.json(
+            by_alias=True,
+            exclude_none=True,
+            indent=2,
+        )
+
+
+class Int8Schema(Schema):
+    type_: str = PydanticField(default="INT8", alias="type", const=True)
+
+
+class Int16Schema(Schema):
+    type_: str = PydanticField(default="INT16", alias="type", const=True)
+
+
+class Int32Schema(Schema):
+    type_: str = PydanticField(default="INT32", alias="type", const=True)
+
+
+class Int64Schema(Schema):
+    type_: str = PydanticField(default="INT64", alias="type", const=True)
+
+
+class Float32Schema(Schema):
+    type_: str = PydanticField(default="FLOAT32", alias="type", const=True)
+
+
+class Float64Schema(Schema):
+    type_: str = PydanticField(default="FLOAT64", alias="type", const=True)
+
+
+class BooleanSchema(Schema):
+    type_: str = PydanticField(default="BOOLEAN", alias="type", const=True)
+
+
+class StringSchema(Schema):
+    type_: str = PydanticField(default="STRING", alias="type", const=True)
+
+
+class BytesSchema(Schema):
+    type_: str = PydanticField(default="BYTES", alias="type", const=True)
+
+
+class ArraySchema(Schema):
+    type_: str = PydanticField(default="ARRAY", alias="type", const=True)
+
+    value_schema: Schema
+    """
+    Value schema for this map or array schema. Throws a ValueError if schema is
+    not a map or array.
+    """
+
+
+class MapSchema(Schema):
+    type_: str = PydanticField(default="MAP", alias="type", const=True)
+
+    key_schema: Schema
+    """
+    Key schema for this map schema. Throws a ValueError if schema is not a map.
+    """
+
+    value_schema: Schema
+    """
+    Value schema for this map or array schema. Throws a ValueError if schema is
+    not a map or array.
+    """
+
+
+class StructSchema(Schema):
+    type_: str = PydanticField(default="STRUCT", alias="type", const=True)
+
     fields: list[Field]
     """
-    Fields in the schema.
+    List of fields for this struct.
     """
+
+    def field(self, name: str) -> Field | None:
+        for field in self.fields or []:
+            if field.name == name:
+                return field
+
+
+class DateSchema(Schema):
+    type_: str = PydanticField(default="DATE", alias="type", const=True)
+
+
+class DecimalSchema(Schema):
+    type_: str = PydanticField(default="DECIMAL", alias="type", const=True)
+
+
+class TimeSchema(Schema):
+    type_: str = PydanticField(default="TIME", alias="type", const=True)
+
+
+class TimestampSchema(Schema):
+    type_: str = PydanticField(default="TIMESTAMP", alias="type", const=True)
+
+
+class UnionSchema(Schema):
+    type_: str = PydanticField(default="UNION", alias="type", const=True)
+
+    schemas: list[Schema]
+
+
+# Update forward refs since Schema references Field, which references Schema.
+Schema.update_forward_refs()
+Field.update_forward_refs()

--- a/recap/schema/avro.py
+++ b/recap/schema/avro.py
@@ -1,0 +1,100 @@
+from typing import Any
+
+from recap import metadata
+
+
+# TODO support referencing named complex types
+# TODO support Enums
+def from_avro(avro_schema: dict[str, Any]) -> metadata.Schema:
+    schema_args = {
+        # Optional is modeled by a union type of ["null", "other_type"].
+        "optional": False,
+    }
+    if name := avro_schema.get("name"):
+        schema_args["name"] = name
+    if doc := avro_schema.get("doc"):
+        schema_args["doc"] = doc
+    if default := avro_schema.get("default"):
+        schema_args["default"] = default
+    match avro_schema.get("type"):
+        case "string":
+            return metadata.StringSchema(**schema_args)
+        case "boolean":
+            return metadata.BooleanSchema(**schema_args)
+        case "int":
+            return metadata.Int32Schema(**schema_args)
+        case "long":
+            return metadata.Int64Schema(**schema_args)
+        case "float":
+            return metadata.Float32Schema(**schema_args)
+        case "double":
+            return metadata.Float64Schema(**schema_args)
+        case "bytes":
+            return metadata.BytesSchema(**schema_args)
+        case dict() as type:
+            return from_avro(type)
+        case list():
+            types = avro_schema.get("type", [])
+            is_optional = "null" in types
+            if len(types) == 2 and is_optional:
+                # This is just a basic optional type, so grab non-null type and
+                # use it as the schema.
+                other_type = [type_ for type_ in types if type_ != "null"][0]
+                if not isinstance(other_type, dict):
+                    other_type = {"type": other_type}
+                schema = from_avro(other_type)
+                schema.optional = True
+                return schema
+            else:
+                return metadata.UnionSchema(
+                    schemas=[
+                        from_avro({"type": avro_schema})
+                        if not isinstance(avro_schema, dict)
+                        else from_avro(avro_schema)
+                        for avro_schema in types
+                        if avro_schema != "null"
+                    ],
+                    optional=is_optional,
+                )
+        case "record":
+            fields = []
+            for field in avro_schema.get("fields", []):
+                field_type = field["type"]
+                if not isinstance(field_type, dict):
+                    field_type = {"type": field_type}
+                fields.append(
+                    metadata.Field(
+                        name=field["name"],
+                        schema=from_avro(field_type),
+                    )
+                )
+            return metadata.StructSchema(
+                fields=fields,
+                **schema_args,
+            )
+        case "array":
+            items = avro_schema["items"]
+            # Primitives are goofy in Avro arrays.
+            if not isinstance(items, dict):
+                items = {"type": items}
+            schema = from_avro(items)
+            return metadata.ArraySchema(
+                value_schema=schema,
+                **schema_args,
+            )
+        case "map":
+            values = avro_schema["values"]
+            # Primitives are goofy in Avro maps.
+            if not isinstance(values, dict):
+                values = {"type": values}
+            schema = from_avro(values)
+            return metadata.MapSchema(
+                key_schema=metadata.StringSchema(),
+                value_schema=schema,
+                **schema_args,
+            )
+        case _:
+            raise ValueError(
+                "Can't convert to Recap type from Avro "
+                f"type={avro_schema.get('type')}"
+            )

--- a/recap/schema/bigquery.py
+++ b/recap/schema/bigquery.py
@@ -1,0 +1,43 @@
+from google.cloud.bigquery import SchemaField
+
+from recap import metadata
+
+
+def to_recap_schema(columns: list[SchemaField]) -> metadata.StructSchema:
+    fields = []
+    for column in columns:
+        match column.field_type:
+            case "STRING":
+                SchemaClass = metadata.StringSchema
+            case "BYTES":
+                SchemaClass = metadata.BytesSchema
+            case "INTEGER" | "INT64":
+                SchemaClass = metadata.Int64Schema
+            case "FLOAT" | "FLOAT64":
+                SchemaClass = metadata.Float64Schema
+            case "BOOLEAN" | "BOOL":
+                SchemaClass = metadata.BooleanSchema
+            case "TIMESTAMP":
+                SchemaClass = metadata.TimestampSchema
+            case "TIME":
+                SchemaClass = metadata.TimeSchema
+            case "DATE":
+                SchemaClass = metadata.DateSchema
+            case "NUMERIC" | "BIGNUMERIC":
+                SchemaClass = metadata.DecimalSchema
+            case _:
+                raise ValueError(
+                    "Can't convert to Recap type from bigquery "
+                    f"type={column.field_type}"
+                )
+        fields.append(
+            metadata.Field(
+                name=column.name,
+                schema=SchemaClass(
+                    default=column.default_value_expression,
+                    optional=column.is_nullable,
+                    doc=column.description,
+                ),
+            )
+        )
+    return metadata.StructSchema(fields=fields, optional=False)

--- a/recap/schema/frictionless.py
+++ b/recap/schema/frictionless.py
@@ -1,0 +1,39 @@
+from frictionless.schema import Schema as FrictionlessSchema
+
+from recap import metadata
+
+
+def to_recap_schema(
+    frictionless_schema: FrictionlessSchema,
+) -> metadata.StructSchema:
+    fields = []
+    for frictionless_field in frictionless_schema.fields:
+        match frictionless_field.type:
+            case "string":
+                SchemaClass = metadata.StringSchema
+            case "number":
+                SchemaClass = metadata.Float64Schema
+            case "integer":
+                SchemaClass = metadata.Int64Schema
+            case "boolean":
+                SchemaClass = metadata.BooleanSchema
+            case "datetime":
+                SchemaClass = metadata.TimestampSchema
+            case "yearmonth":
+                SchemaClass = metadata.StringSchema
+            # TODO Should handle types (object, array) here.
+            case _:
+                raise ValueError(
+                    "Can't convert to Recap type from frictionless "
+                    f"type={frictionless_field.type}"
+                )
+        fields.append(
+            metadata.Field(
+                name=frictionless_field.name,
+                schema=SchemaClass(
+                    doc=frictionless_field.description,
+                    optional=frictionless_field.required,
+                ),
+            )
+        )
+    return metadata.StructSchema(fields=fields, optional=False)

--- a/recap/schema/json_schema.py
+++ b/recap/schema/json_schema.py
@@ -1,0 +1,159 @@
+from typing import Any
+
+from recap import metadata
+
+DEFAULT_SCHEMA_VERSION = "https://json-schema.org/draft/2020-12/schema"
+
+
+def from_json_schema(json_schema: dict[str, Any]) -> metadata.Schema:
+    match json_schema.get("type"):
+        case "integer":
+            return metadata.Int64Schema(
+                name=json_schema.get("title"),
+                default=json_schema.get("default"),
+                doc=json_schema.get("description"),
+            )
+        case "string" if json_schema.get("format") == "date-time":
+            return metadata.TimestampSchema(
+                name=json_schema.get("title"),
+                default=json_schema.get("default"),
+                doc=json_schema.get("description"),
+            )
+        case "string" if json_schema.get("format") == "date":
+            return metadata.DateSchema(
+                name=json_schema.get("title"),
+                default=json_schema.get("default"),
+                doc=json_schema.get("description"),
+            )
+        case "string" if json_schema.get("format") == "time":
+            return metadata.TimeSchema(
+                name=json_schema.get("title"),
+                default=json_schema.get("default"),
+                doc=json_schema.get("description"),
+            )
+        case "string":
+            return metadata.StringSchema(
+                name=json_schema.get("title"),
+                default=json_schema.get("default"),
+                doc=json_schema.get("description"),
+            )
+        case "number":
+            return metadata.Float64Schema(
+                name=json_schema.get("title"),
+                default=json_schema.get("default"),
+                doc=json_schema.get("description"),
+            )
+        case "boolean":
+            return metadata.BooleanSchema(
+                name=json_schema.get("title"),
+                default=json_schema.get("default"),
+                doc=json_schema.get("description"),
+            )
+        case "object":
+            fields = []
+            properties = json_schema.get("properties", {})
+            required = set(json_schema.get("required", []))
+            for name, field_schema in properties.items():
+                schema = from_json_schema(field_schema)
+                schema.optional = name in required
+                fields.append(
+                    metadata.Field(
+                        name=name,
+                        schema=schema,
+                    )
+                )
+            return metadata.StructSchema(
+                name=json_schema.get("title"),
+                default=json_schema.get("default"),
+                doc=json_schema.get("description"),
+                fields=fields,
+            )
+        case "array":
+            schema = from_json_schema(json_schema.get("items", {}))
+            return metadata.ArraySchema(
+                name=json_schema.get("title"),
+                default=json_schema.get("default"),
+                doc=json_schema.get("description"),
+                value_schema=schema,
+            )
+        case _:
+            raise ValueError(
+                "Can't convert to Recap type from JSON schema "
+                f"type={json_schema.get('type')}"
+            )
+
+
+def to_json_schema(
+    schema: metadata.Schema,
+    json_schema_ver: str | None = DEFAULT_SCHEMA_VERSION,
+) -> dict[str, Any]:
+    json_schema = {}
+    if schema.name:
+        json_schema["title"] = schema.name
+    if schema.doc:
+        json_schema["description"] = schema.doc
+    match schema:
+        case (
+            metadata.Int8Schema()
+            | metadata.Int16Schema()
+            | metadata.Int32Schema()
+            | metadata.Int64Schema()
+        ):
+            json_schema["type"] = "integer"
+        case metadata.StringSchema():
+            json_schema["type"] = "string"
+        case (metadata.Float32Schema() | metadata.Float64Schema()):
+            json_schema["type"] = "number"
+        case metadata.BooleanSchema():
+            json_schema["type"] = "boolean"
+        case metadata.TimestampSchema():
+            json_schema |= {
+                "type": "string",
+                "format": "date-time",
+            }
+        case metadata.DateSchema():
+            json_schema |= {
+                "type": "string",
+                "format": "date",
+            }
+        case metadata.TimeSchema():
+            json_schema |= {
+                "type": "string",
+                "format": "time",
+            }
+        case metadata.ArraySchema() if schema.value_schema:
+            json_schema |= {
+                "type": "array",
+                "items": to_json_schema(schema.value_schema, None),
+            }
+        case metadata.StructSchema():
+            properties = {}
+            required = []
+            json_schema["type"] = "object"
+            for field in schema.fields or []:
+                properties[field.name] = to_json_schema(field.schema_, None)
+                if not field.schema_.optional:
+                    required.append(field.name)
+            if json_schema_ver:
+                json_schema["$schema"] = json_schema_ver
+            if properties:
+                json_schema["properties"] = properties
+            if required:
+                json_schema["required"] = required
+        case metadata.MapSchema(
+            key_schema=metadata.StringSchema(),
+            value_schema=metadata.Schema(),
+        ):
+            json_schema |= {
+                "type": "object",
+                "additionalProperties": to_json_schema(schema.value_schema),  # type: ignore
+            }
+        case metadata.UnionSchema():
+            json_schema["anyOf"] = [
+                to_json_schema(union_subschema) for union_subschema in schema.schemas
+            ]
+        case _:
+            raise ValueError(
+                f"Can't convert from Recap type to JSON schema schema={schema}"
+            )
+    return json_schema

--- a/recap/schema/sqlalchemy.py
+++ b/recap/schema/sqlalchemy.py
@@ -1,0 +1,49 @@
+from typing import Any
+
+from sqlalchemy import types
+
+from recap import metadata
+
+
+def to_recap_schema(columns: list[dict[str, Any]]) -> metadata.StructSchema:
+    fields = []
+    for column in columns:
+        match column["type"]:
+            case types.SmallInteger():
+                SchemaClass = metadata.Int16Schema
+            case types.Integer():
+                SchemaClass = metadata.Int32Schema
+            case types.BigInteger():
+                SchemaClass = metadata.Int64Schema
+            case types.Boolean():
+                SchemaClass = metadata.BooleanSchema
+            case types.Float():
+                SchemaClass = metadata.Float32Schema
+            case types.LargeBinary() | types._Binary():
+                SchemaClass = metadata.BytesSchema
+            case types.Numeric():
+                SchemaClass = metadata.DecimalSchema
+            case types.String() | types.Text() | types.Unicode() | types.UnicodeText() | types.JSON():
+                SchemaClass = metadata.StringSchema
+            case types.TIMESTAMP() | types.DATETIME():
+                SchemaClass = metadata.TimestampSchema
+            case types.TIME():
+                SchemaClass = metadata.TimeSchema
+            case types.DATE():
+                SchemaClass = metadata.DateSchema
+            case _:
+                raise ValueError(
+                    "Can't convert to Recap type from frictionless "
+                    f"type={type(column['type'])}"
+                )
+        fields.append(
+            metadata.Field(
+                name=column["name"],
+                schema=SchemaClass(
+                    default=column["default"],
+                    optional=column["nullable"],
+                    doc=column.get("comment"),
+                ),
+            )
+        )
+    return metadata.StructSchema(fields=fields, optional=False)

--- a/recap/schema/sqlglot.py
+++ b/recap/schema/sqlglot.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from sqlglot import transpile
+
+from recap import metadata
+
+
+def to_ddl(
+    schema: metadata.Schema,
+    table: str,
+    dialect: str,
+    primary_key: str | None = "id",
+) -> str:
+    column_defs = _get_column_defs(schema, True, primary_key)
+    sql = f"CREATE TABLE {table} ({column_defs})"
+    return "\n".join(
+        transpile(
+            sql,
+            read="duckdb",
+            write=dialect,
+            identify=True,
+            pretty=True,
+        )
+    )
+
+
+def _get_column_defs(
+    schema: metadata.Schema,
+    is_root: bool = False,
+    primary_key: str | None = None,
+) -> str:
+    column_def = ""
+    match schema:
+        case metadata.Int16Schema():
+            column_def = "SMALLINT"
+        case metadata.Int32Schema():
+            column_def = "INTEGER"
+        case metadata.Int64Schema():
+            column_def = "BIGINT"
+        case metadata.Float32Schema():
+            column_def = "REAL"
+        case metadata.Float64Schema():
+            column_def = "DOUBLE"
+        case metadata.BooleanSchema():
+            column_def = "BOOLEAN"
+        case metadata.StringSchema():
+            column_def = "VARCHAR"
+        case metadata.BytesSchema():
+            column_def = "BLOB"
+        case metadata.TimestampSchema():
+            column_def = "TIMESTAMP"
+        case metadata.DateSchema():
+            column_def = "DATE"
+        case metadata.TimeSchema():
+            column_def = "TIME"
+        case metadata.ArraySchema() if schema.value_schema:
+            column_def = f"{_get_column_defs(schema.value_schema)}[]"
+        case metadata.StructSchema():
+            for field in schema.fields or []:
+                field_def = _get_column_defs(field.schema_)
+                if is_root and field.name == primary_key:
+                    field_def += " PRIMARY KEY"
+                elif is_root and not field.schema_.optional:
+                    field_def += " NOT NULL"
+                column_def += f"{field.name} {field_def}, "
+            column_def = column_def.rstrip(", ")
+            if not is_root:
+                column_def = f"STRUCT({column_def})"
+        case metadata.MapSchema(
+            key_schema=metadata.Schema(),
+            value_schema=metadata.Schema(),
+        ):
+            key_def = _get_column_defs(schema.key_schema)  # type: ignore
+            value_def = _get_column_defs(schema.value_schema)  # type: ignore
+            column_def = f"MAP({key_def}, {value_def})"
+        case _:
+            raise ValueError(
+                f"Can't convert to DuckDB DDL from Recap type={schema.type_}"
+            )
+    return column_def


### PR DESCRIPTION
I've added a bunch of (rough) code for converting to and from Recap schemas.

Currently, you can convert from:

* Avro
* Parquet
* CSV/TSV
* JSON files and JSON schemas
* BigQuery
* SQLAlchemy DBs

To:

* JSON Schemas
* `create_table` DDL (using `sqlglot`)

Recap's schema structure is used as the intermediary.