### PR TITLE
Move `Schema` model into `recap.schema.model` module

### DIFF
--- a/recap/catalog.py
+++ b/recap/catalog.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from enum import Enum
 from urllib.parse import urlparse
 
-from recap.metadata import Schema
 from recap.registry import FunctionRegistry
 from recap.registry import registry as global_registry
+from recap.schema.model import Schema
 from recap.storage.abstract import AbstractStorage, Direction, MetadataSubtype
 
 

--- a/recap/cli.py
+++ b/recap/cli.py
@@ -7,7 +7,7 @@ from rich import print_json
 
 from recap import repl
 from recap.logging import setup_logging
-from recap.metadata import Schema
+from recap.schema.model import Schema
 
 app = typer.Typer(
     help="""

--- a/recap/integrations/bigquery.py
+++ b/recap/integrations/bigquery.py
@@ -4,9 +4,9 @@ from google.cloud.bigquery import Client
 from sqlalchemy import inspect
 from sqlalchemy.engine import Engine
 
-from recap.metadata import Schema
 from recap.registry import registry
-from recap.schema.bigquery import to_recap_schema
+from recap.schema.converters.bigquery import to_recap_schema
+from recap.schema.model import Schema
 from recap.storage.abstract import Direction
 
 

--- a/recap/integrations/fsspec.py
+++ b/recap/integrations/fsspec.py
@@ -6,9 +6,9 @@ from frictionless import Resource, describe  # type: ignore
 from fsspec import AbstractFileSystem
 from genson import SchemaBuilder
 
-from recap.metadata import Schema
 from recap.registry import registry
-from recap.schema import frictionless, json_schema
+from recap.schema.converters import frictionless, json_schema
+from recap.schema.model import Schema
 
 
 @registry.relationship(

--- a/recap/integrations/sqlalchemy.py
+++ b/recap/integrations/sqlalchemy.py
@@ -15,9 +15,9 @@ from __future__ import annotations
 from sqlalchemy import inspect
 from sqlalchemy.engine import Engine
 
-from recap.metadata import Schema
 from recap.registry import registry
-from recap.schema.sqlalchemy import to_recap_schema
+from recap.schema.converters.sqlalchemy import to_recap_schema
+from recap.schema.model import Schema
 
 
 @registry.metadata(

--- a/recap/repl.py
+++ b/recap/repl.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 from recap.catalog import create_catalog
 from recap.crawler import create_crawler
-from recap.metadata import Schema
+from recap.schema.model import Schema
 from recap.storage.abstract import MetadataSubtype
 
 catalog = create_catalog()

--- a/recap/schema/converters/avro.py
+++ b/recap/schema/converters/avro.py
@@ -1,11 +1,11 @@
 from typing import Any
 
-from recap import metadata
+from recap.schema import model
 
 
 # TODO support referencing named complex types
 # TODO support Enums
-def from_avro(avro_schema: dict[str, Any]) -> metadata.Schema:
+def from_avro(avro_schema: dict[str, Any]) -> model.Schema:
     schema_args = {
         # Optional is modeled by a union type of ["null", "other_type"].
         "optional": False,
@@ -18,19 +18,19 @@ def from_avro(avro_schema: dict[str, Any]) -> metadata.Schema:
         schema_args["default"] = default
     match avro_schema.get("type"):
         case "string":
-            return metadata.StringSchema(**schema_args)
+            return model.StringSchema(**schema_args)
         case "boolean":
-            return metadata.BooleanSchema(**schema_args)
+            return model.BooleanSchema(**schema_args)
         case "int":
-            return metadata.Int32Schema(**schema_args)
+            return model.Int32Schema(**schema_args)
         case "long":
-            return metadata.Int64Schema(**schema_args)
+            return model.Int64Schema(**schema_args)
         case "float":
-            return metadata.Float32Schema(**schema_args)
+            return model.Float32Schema(**schema_args)
         case "double":
-            return metadata.Float64Schema(**schema_args)
+            return model.Float64Schema(**schema_args)
         case "bytes":
-            return metadata.BytesSchema(**schema_args)
+            return model.BytesSchema(**schema_args)
         case dict() as type:
             return from_avro(type)
         case list():
@@ -46,7 +46,7 @@ def from_avro(avro_schema: dict[str, Any]) -> metadata.Schema:
                 schema.optional = True
                 return schema
             else:
-                return metadata.UnionSchema(
+                return model.UnionSchema(
                     schemas=[
                         from_avro({"type": avro_schema})
                         if not isinstance(avro_schema, dict)
@@ -63,12 +63,12 @@ def from_avro(avro_schema: dict[str, Any]) -> metadata.Schema:
                 if not isinstance(field_type, dict):
                     field_type = {"type": field_type}
                 fields.append(
-                    metadata.Field(
+                    model.Field(
                         name=field["name"],
                         schema=from_avro(field_type),
                     )
                 )
-            return metadata.StructSchema(
+            return model.StructSchema(
                 fields=fields,
                 **schema_args,
             )
@@ -78,7 +78,7 @@ def from_avro(avro_schema: dict[str, Any]) -> metadata.Schema:
             if not isinstance(items, dict):
                 items = {"type": items}
             schema = from_avro(items)
-            return metadata.ArraySchema(
+            return model.ArraySchema(
                 value_schema=schema,
                 **schema_args,
             )
@@ -88,8 +88,8 @@ def from_avro(avro_schema: dict[str, Any]) -> metadata.Schema:
             if not isinstance(values, dict):
                 values = {"type": values}
             schema = from_avro(values)
-            return metadata.MapSchema(
-                key_schema=metadata.StringSchema(),
+            return model.MapSchema(
+                key_schema=model.StringSchema(),
                 value_schema=schema,
                 **schema_args,
             )

--- a/recap/schema/converters/bigquery.py
+++ b/recap/schema/converters/bigquery.py
@@ -1,37 +1,37 @@
 from google.cloud.bigquery import SchemaField
 
-from recap import metadata
+from recap.schema import model
 
 
-def to_recap_schema(columns: list[SchemaField]) -> metadata.StructSchema:
+def to_recap_schema(columns: list[SchemaField]) -> model.StructSchema:
     fields = []
     for column in columns:
         match column.field_type:
             case "STRING":
-                SchemaClass = metadata.StringSchema
+                SchemaClass = model.StringSchema
             case "BYTES":
-                SchemaClass = metadata.BytesSchema
+                SchemaClass = model.BytesSchema
             case "INTEGER" | "INT64":
-                SchemaClass = metadata.Int64Schema
+                SchemaClass = model.Int64Schema
             case "FLOAT" | "FLOAT64":
-                SchemaClass = metadata.Float64Schema
+                SchemaClass = model.Float64Schema
             case "BOOLEAN" | "BOOL":
-                SchemaClass = metadata.BooleanSchema
+                SchemaClass = model.BooleanSchema
             case "TIMESTAMP":
-                SchemaClass = metadata.TimestampSchema
+                SchemaClass = model.TimestampSchema
             case "TIME":
-                SchemaClass = metadata.TimeSchema
+                SchemaClass = model.TimeSchema
             case "DATE":
-                SchemaClass = metadata.DateSchema
+                SchemaClass = model.DateSchema
             case "NUMERIC" | "BIGNUMERIC":
-                SchemaClass = metadata.DecimalSchema
+                SchemaClass = model.DecimalSchema
             case _:
                 raise ValueError(
                     "Can't convert to Recap type from bigquery "
                     f"type={column.field_type}"
                 )
         fields.append(
-            metadata.Field(
+            model.Field(
                 name=column.name,
                 schema=SchemaClass(
                     default=column.default_value_expression,
@@ -40,4 +40,4 @@ def to_recap_schema(columns: list[SchemaField]) -> metadata.StructSchema:
                 ),
             )
         )
-    return metadata.StructSchema(fields=fields, optional=False)
+    return model.StructSchema(fields=fields, optional=False)

--- a/recap/schema/converters/frictionless.py
+++ b/recap/schema/converters/frictionless.py
@@ -1,26 +1,26 @@
 from frictionless.schema import Schema as FrictionlessSchema
 
-from recap import metadata
+from recap.schema import model
 
 
 def to_recap_schema(
     frictionless_schema: FrictionlessSchema,
-) -> metadata.StructSchema:
+) -> model.StructSchema:
     fields = []
     for frictionless_field in frictionless_schema.fields:
         match frictionless_field.type:
             case "string":
-                SchemaClass = metadata.StringSchema
+                SchemaClass = model.StringSchema
             case "number":
-                SchemaClass = metadata.Float64Schema
+                SchemaClass = model.Float64Schema
             case "integer":
-                SchemaClass = metadata.Int64Schema
+                SchemaClass = model.Int64Schema
             case "boolean":
-                SchemaClass = metadata.BooleanSchema
+                SchemaClass = model.BooleanSchema
             case "datetime":
-                SchemaClass = metadata.TimestampSchema
+                SchemaClass = model.TimestampSchema
             case "yearmonth":
-                SchemaClass = metadata.StringSchema
+                SchemaClass = model.StringSchema
             # TODO Should handle types (object, array) here.
             case _:
                 raise ValueError(
@@ -28,7 +28,7 @@ def to_recap_schema(
                     f"type={frictionless_field.type}"
                 )
         fields.append(
-            metadata.Field(
+            model.Field(
                 name=frictionless_field.name,
                 schema=SchemaClass(
                     doc=frictionless_field.description,
@@ -36,4 +36,4 @@ def to_recap_schema(
                 ),
             )
         )
-    return metadata.StructSchema(fields=fields, optional=False)
+    return model.StructSchema(fields=fields, optional=False)

--- a/recap/schema/converters/sqlalchemy.py
+++ b/recap/schema/converters/sqlalchemy.py
@@ -2,42 +2,42 @@ from typing import Any
 
 from sqlalchemy import types
 
-from recap import metadata
+from recap.schema import model
 
 
-def to_recap_schema(columns: list[dict[str, Any]]) -> metadata.StructSchema:
+def to_recap_schema(columns: list[dict[str, Any]]) -> model.StructSchema:
     fields = []
     for column in columns:
         match column["type"]:
             case types.SmallInteger():
-                SchemaClass = metadata.Int16Schema
+                SchemaClass = model.Int16Schema
             case types.Integer():
-                SchemaClass = metadata.Int32Schema
+                SchemaClass = model.Int32Schema
             case types.BigInteger():
-                SchemaClass = metadata.Int64Schema
+                SchemaClass = model.Int64Schema
             case types.Boolean():
-                SchemaClass = metadata.BooleanSchema
+                SchemaClass = model.BooleanSchema
             case types.Float():
-                SchemaClass = metadata.Float32Schema
+                SchemaClass = model.Float32Schema
             case types.LargeBinary() | types._Binary():
-                SchemaClass = metadata.BytesSchema
+                SchemaClass = model.BytesSchema
             case types.Numeric():
-                SchemaClass = metadata.DecimalSchema
+                SchemaClass = model.DecimalSchema
             case types.String() | types.Text() | types.Unicode() | types.UnicodeText() | types.JSON():
-                SchemaClass = metadata.StringSchema
+                SchemaClass = model.StringSchema
             case types.TIMESTAMP() | types.DATETIME():
-                SchemaClass = metadata.TimestampSchema
+                SchemaClass = model.TimestampSchema
             case types.TIME():
-                SchemaClass = metadata.TimeSchema
+                SchemaClass = model.TimeSchema
             case types.DATE():
-                SchemaClass = metadata.DateSchema
+                SchemaClass = model.DateSchema
             case _:
                 raise ValueError(
                     "Can't convert to Recap type from frictionless "
                     f"type={type(column['type'])}"
                 )
         fields.append(
-            metadata.Field(
+            model.Field(
                 name=column["name"],
                 schema=SchemaClass(
                     default=column["default"],
@@ -46,4 +46,4 @@ def to_recap_schema(columns: list[dict[str, Any]]) -> metadata.StructSchema:
                 ),
             )
         )
-    return metadata.StructSchema(fields=fields, optional=False)
+    return model.StructSchema(fields=fields, optional=False)

--- a/recap/schema/converters/sqlglot.py
+++ b/recap/schema/converters/sqlglot.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from sqlglot import transpile
 
-from recap import metadata
+from recap.schema import model
 
 
 def to_ddl(
-    schema: metadata.Schema,
+    schema: model.Schema,
     table: str,
     dialect: str,
     primary_key: str | None = "id",
@@ -25,37 +25,37 @@ def to_ddl(
 
 
 def _get_column_defs(
-    schema: metadata.Schema,
+    schema: model.Schema,
     is_root: bool = False,
     primary_key: str | None = None,
 ) -> str:
     column_def = ""
     match schema:
-        case metadata.Int16Schema():
+        case model.Int16Schema():
             column_def = "SMALLINT"
-        case metadata.Int32Schema():
+        case model.Int32Schema():
             column_def = "INTEGER"
-        case metadata.Int64Schema():
+        case model.Int64Schema():
             column_def = "BIGINT"
-        case metadata.Float32Schema():
+        case model.Float32Schema():
             column_def = "REAL"
-        case metadata.Float64Schema():
+        case model.Float64Schema():
             column_def = "DOUBLE"
-        case metadata.BooleanSchema():
+        case model.BooleanSchema():
             column_def = "BOOLEAN"
-        case metadata.StringSchema():
+        case model.StringSchema():
             column_def = "VARCHAR"
-        case metadata.BytesSchema():
+        case model.BytesSchema():
             column_def = "BLOB"
-        case metadata.TimestampSchema():
+        case model.TimestampSchema():
             column_def = "TIMESTAMP"
-        case metadata.DateSchema():
+        case model.DateSchema():
             column_def = "DATE"
-        case metadata.TimeSchema():
+        case model.TimeSchema():
             column_def = "TIME"
-        case metadata.ArraySchema() if schema.value_schema:
+        case model.ArraySchema() if schema.value_schema:
             column_def = f"{_get_column_defs(schema.value_schema)}[]"
-        case metadata.StructSchema():
+        case model.StructSchema():
             for field in schema.fields or []:
                 field_def = _get_column_defs(field.schema_)
                 if is_root and field.name == primary_key:
@@ -66,9 +66,9 @@ def _get_column_defs(
             column_def = column_def.rstrip(", ")
             if not is_root:
                 column_def = f"STRUCT({column_def})"
-        case metadata.MapSchema(
-            key_schema=metadata.Schema(),
-            value_schema=metadata.Schema(),
+        case model.MapSchema(
+            key_schema=model.Schema(),
+            value_schema=model.Schema(),
         ):
             key_def = _get_column_defs(schema.key_schema)  # type: ignore
             value_def = _get_column_defs(schema.value_schema)  # type: ignore

--- a/recap/schema/model.py
+++ b/recap/schema/model.py
@@ -8,7 +8,7 @@ accounts and jobs, are represented by URLs, but have no associated metadata.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import Any
 
 from pydantic import BaseModel
 from pydantic import Field as PydanticField

--- a/recap/server.py
+++ b/recap/server.py
@@ -3,7 +3,7 @@ from typing import Generator
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
 
-from recap.metadata import Schema
+from recap.schema.model import Schema
 from recap.storage import create_storage
 from recap.storage.abstract import AbstractStorage, Direction
 


### PR DESCRIPTION
I decided to eliminate the `metadata.py` file and move models into specific `model.py` files in their respective subdirectories. I want to start structuring Recap in a more modular way. This is a step in that direction.