### PR TITLE
Add basic protobuf conversion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@
 
 ## About
 
-Recap reads and converts schemas in dozens of formats including [Parquet](https://parquet.apache.org), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org), [BigQuery](https://cloud.google.com/bigquery), [Snowflake](https://www.snowflake.com/), and [PostgreSQL](https://www.postgresql.org/).
+Recap reads and converts schemas in dozens of formats including [Parquet](https://parquet.apache.org), [Protocol Buffers](https://protobuf.dev/), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org), [BigQuery](https://cloud.google.com/bigquery), [Snowflake](https://www.snowflake.com/), and [PostgreSQL](https://www.postgresql.org/).
 
 ## Features
 
 * Read schemas from filesystems, object stores, and databases.
-* Convert schemas between [Parquet](https://parquet.apache.org), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org).
+* Convert schemas between [Parquet](https://parquet.apache.org), [Protocol Buffers](https://protobuf.dev/), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org).
 * Generate `CREATE TABLE` DDL from schemas for popular database SQL dialects.
 * Infer schemas from unstructured data like CSV, TSV, and JSON.
 
@@ -29,7 +29,7 @@ Recap reads and converts schemas in dozens of formats including [Parquet](https:
 
 * Any [SQLAlchemy-compatible](https://docs.sqlalchemy.org/en/13/dialects/) database
 * Any [fsspec-compatible](https://filesystem-spec.readthedocs.io) filesystem
-* [Parquet](https://parquet.apache.org), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org)
+* [Parquet](https://parquet.apache.org), [Protocol Buffers](https://protobuf.dev/), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org)
 * CSV, TSV, and JSON files
 
 ## Installation
@@ -38,13 +38,19 @@ Recap reads and converts schemas in dozens of formats including [Parquet](https:
 
 ## Examples
 
-Read schemas from filesystems:
+Read schemas from objects:
+
+```
+s = from_proto(message)
+```
+
+Or files:
 
 ```python
 s = schema("s3://corp-logs/2022-03-01/0.json")
 ```
 
-And databases:
+Or databases:
 
 ```python
 s = schema("snowflake://ycbjbzl-ib10693/TEST_DB/PUBLIC/311_service_requests")

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,12 +22,12 @@
 </p>
 
 
-Recap reads and converts schemas in dozens of formats including [Parquet](https://parquet.apache.org), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org), [BigQuery](https://cloud.google.com/bigquery), [Snowflake](https://www.snowflake.com/), and [PostgreSQL](https://www.postgresql.org/).
+Recap reads and converts schemas in dozens of formats including [Parquet](https://parquet.apache.org), [Protocol Buffers](https://protobuf.dev/), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org), [BigQuery](https://cloud.google.com/bigquery), [Snowflake](https://www.snowflake.com/), and [PostgreSQL](https://www.postgresql.org/).
 
 ## Features
 
 * Read schemas from filesystems, object stores, and databases.
-* Convert schemas between [Parquet](https://parquet.apache.org), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org).
+* Convert schemas between [Parquet](https://parquet.apache.org), [Protocol Buffers](https://protobuf.dev/), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org).
 * Generate `CREATE TABLE` DDL from schemas for popular database SQL dialects.
 * Infer schemas from unstructured data like CSV, TSV, and JSON.
 
@@ -35,7 +35,7 @@ Recap reads and converts schemas in dozens of formats including [Parquet](https:
 
 * Any [SQLAlchemy-compatible](https://docs.sqlalchemy.org/en/13/dialects/) database
 * Any [fsspec-compatible](https://filesystem-spec.readthedocs.io) filesystem
-* [Parquet](https://parquet.apache.org), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org)
+* [Parquet](https://parquet.apache.org), [Protocol Buffers](https://protobuf.dev/), [Avro](https://avro.apache.org), and [JSON schema](https://json-schema.org)
 * CSV, TSV, and JSON files
 
 ## Installation
@@ -44,13 +44,19 @@ Recap reads and converts schemas in dozens of formats including [Parquet](https:
 
 ## Examples
 
-Read schemas from filesystems:
+Read schemas from objects:
+
+```
+s = from_proto(message)
+```
+
+Or files:
 
 ```python
 s = schema("s3://corp-logs/2022-03-01/0.json")
 ```
 
-And databases:
+Or databases:
 
 ```python
 s = schema("snowflake://ycbjbzl-ib10693/TEST_DB/PUBLIC/311_service_requests")

--- a/pdm.lock
+++ b/pdm.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "4.21.12"
+version = "4.22.0"
 requires_python = ">=3.7"
 summary = ""
 
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:696ac871deb3931a84edf2bdcc24a3fd34dd7afdf36160397a6e27034a2624af"
+content_hash = "sha256:907786e8462533c2f879e1c9590ceef34de3c8a77a017ea0c385cb2cc99fc63d"
 
 [metadata.files]
 "aiobotocore 2.4.2" = [
@@ -2548,21 +2548,20 @@ content_hash = "sha256:696ac871deb3931a84edf2bdcc24a3fd34dd7afdf36160397a6e27034
     {url = "https://files.pythonhosted.org/packages/38/ab/d5916bd1a56dfc2c9c268effd12a635ef7bbb2c9dc9b0270da72122afabb/proto-plus-1.22.2.tar.gz", hash = "sha256:0e8cda3d5a634d9895b75c573c9352c16486cb75deb0e078b5fda34db4243165"},
     {url = "https://files.pythonhosted.org/packages/f5/0e/a277783e8b7544008e625956dee8bbdec8c65fc4ae103fc5065a290abe92/proto_plus-1.22.2-py3-none-any.whl", hash = "sha256:de34e52d6c9c6fcd704192f09767cb561bb4ee64e70eede20b0834d841f0be4d"},
 ]
-"protobuf 4.21.12" = [
-    {url = "https://files.pythonhosted.org/packages/05/b6/6e9b82445e3561132a871e38f5601b12749beb5305eaa085d7f0c59728c9/protobuf-4.21.12-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791"},
-    {url = "https://files.pythonhosted.org/packages/2e/7a/bcc5593264e37ce8eb597a6a60f1059dfcf96d5ad93ce5934eba405268cc/protobuf-4.21.12-cp38-cp38-win_amd64.whl", hash = "sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30"},
-    {url = "https://files.pythonhosted.org/packages/42/9b/7f464fa46797486439b35fb5aa0dbc99face447396619f1c98da13257732/protobuf-4.21.12-cp310-abi3-win32.whl", hash = "sha256:b135410244ebe777db80298297a97fbb4c862c881b4403b71bac9d4107d61fd1"},
-    {url = "https://files.pythonhosted.org/packages/46/31/9ba4d776af7f8437f997b6d8419e611d1cad21d202ae384402a22118e098/protobuf-4.21.12-cp39-cp39-win32.whl", hash = "sha256:27f4d15021da6d2b706ddc3860fac0a5ddaba34ab679dc182b60a8bb4e1121cc"},
-    {url = "https://files.pythonhosted.org/packages/69/bb/5c26e9de146ade920a23d446de35a3758a3f792fd28679a6f374ea3d1c26/protobuf-4.21.12-cp39-cp39-win_amd64.whl", hash = "sha256:237216c3326d46808a9f7c26fd1bd4b20015fb6867dc5d263a493ef9a539293b"},
-    {url = "https://files.pythonhosted.org/packages/76/74/28f42d3e6b0c7bffaa04348a631de7a22c3d81d1564753301d058c80fff5/protobuf-4.21.12-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97"},
-    {url = "https://files.pythonhosted.org/packages/85/c3/28d3a33b7aafeee9e7f9e0110bf6a057a7f3cc0f0e0cc78cc9fc8a159e30/protobuf-4.21.12-cp38-cp38-win32.whl", hash = "sha256:6ab80df09e3208f742c98443b6166bcb70d65f52cfeb67357d52032ea1ae9bec"},
-    {url = "https://files.pythonhosted.org/packages/a2/9a/3e49093273f62eed1b4bb179f6cc5fc746bbae79de59d44e8d184976ce8a/protobuf-4.21.12-cp37-cp37m-win_amd64.whl", hash = "sha256:f45460f9ee70a0ec1b6694c6e4e348ad2019275680bd68a1d9314b8c7e01e574"},
-    {url = "https://files.pythonhosted.org/packages/ba/dd/f8a01b146bf45ac12a829bbc599e6590aa6a6849ace7d28c42d77041d6ab/protobuf-4.21.12.tar.gz", hash = "sha256:7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab"},
-    {url = "https://files.pythonhosted.org/packages/bc/2d/cda50557649f56f842116aa56bb5384df7582f01fff7344817bfe8de73f3/protobuf-4.21.12-cp37-cp37m-win32.whl", hash = "sha256:3d164928ff0727d97022957c2b849250ca0e64777ee31efd7d6de2e07c494717"},
-    {url = "https://files.pythonhosted.org/packages/c6/3b/33f3bd47dbfdd17ed87024b6473b26ee3a8c3303f019e91557b2654703a4/protobuf-4.21.12-py2.py3-none-any.whl", hash = "sha256:a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5"},
-    {url = "https://files.pythonhosted.org/packages/d4/9f/5cb64224bdd4695f5b024a05a4bea31af1d8e3127d45a74161631fe8180e/protobuf-4.21.12-py3-none-any.whl", hash = "sha256:b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462"},
-    {url = "https://files.pythonhosted.org/packages/e7/a2/3273c05fc5d959fa90de6453ebd6d45c6d4fab3ec212d631625ea5780921/protobuf-4.21.12-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7"},
-    {url = "https://files.pythonhosted.org/packages/f8/21/56796f96eadb1e1974090278312de28c8dced584e38ea7ee770e912c7af2/protobuf-4.21.12-cp310-abi3-win_amd64.whl", hash = "sha256:89f9149e4a0169cddfc44c74f230d7743002e3aa0b9472d8c28f0388102fc4c2"},
+"protobuf 4.22.0" = [
+    {url = "https://files.pythonhosted.org/packages/1e/bf/54a989c36c1f2486d9b16f9ae423ca0060710a92408f1fed1a30c0368f85/protobuf-4.22.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:e894e9ae603e963f0842498c4cd5d39c6a60f0d7e4c103df50ee939564298658"},
+    {url = "https://files.pythonhosted.org/packages/2b/ed/8f2113e3446bc98555cce3a17403180f86c70a51b9e61ef973e9c8df7179/protobuf-4.22.0-py3-none-any.whl", hash = "sha256:c3325803095fb4c2a48649c321d2fbde59f8fbfcb9bfc7a86df27d112831c571"},
+    {url = "https://files.pythonhosted.org/packages/4a/f7/c3eb01258497550cfeaa78776292c1d8951f23829b9bde94e2dc05380346/protobuf-4.22.0-cp310-abi3-win_amd64.whl", hash = "sha256:a33a273d21852f911b8bda47f39f4383fe7c061eb1814db2c76c9875c89c2491"},
+    {url = "https://files.pythonhosted.org/packages/64/ca/f9356369c63530920645a596249ad169e2f4a674ad7b92dd50dc63d2e39f/protobuf-4.22.0-cp38-cp38-win32.whl", hash = "sha256:29288813aacaa302afa2381db1d6e0482165737b0afdf2811df5fa99185c457b"},
+    {url = "https://files.pythonhosted.org/packages/67/46/bd884d95f9b2ec8d4cacb0a3c74600e99728007a6436adb19f97d6442618/protobuf-4.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:c27f371f0159feb70e6ea52ed7e768b3f3a4c5676c1900a7e51a24740381650e"},
+    {url = "https://files.pythonhosted.org/packages/68/d6/d8e2754c00cab8db2bf71f06e4b4bde2e8a30c74f591dc567028bd1d75be/protobuf-4.22.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ab4d043865dd04e6b09386981fe8f80b39a1e46139fb4a3c206229d6b9f36ff6"},
+    {url = "https://files.pythonhosted.org/packages/7e/76/df06bc132557a83e8a3477e50c3ccf06c489a90cdbc78083aa2eaeb60a4c/protobuf-4.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:e474b63bab0a2ea32a7b26a4d8eec59e33e709321e5e16fb66e766b61b82a95e"},
+    {url = "https://files.pythonhosted.org/packages/7f/cf/7ae0168ab8b18b2ecbf5f1443d200c3ea5b71b9723443319abdde781335a/protobuf-4.22.0-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:7c535d126e7dcc714105ab20b418c4fedbd28f8b8afc42b7350b1e317bbbcc71"},
+    {url = "https://files.pythonhosted.org/packages/89/80/d5fc86e6d6761e353b67e616be29224c17a66064ffced0c6f2e3829e3dd8/protobuf-4.22.0-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:86c3d20428b007537ba6792b475c0853bba7f66b1f60e610d913b77d94b486e4"},
+    {url = "https://files.pythonhosted.org/packages/96/ea/f88e86890bb53a099e7b61b0053abf295639ceaf55ec08948696a2e826be/protobuf-4.22.0-cp39-cp39-win32.whl", hash = "sha256:47d31bdf58222dd296976aa1646c68c6ee80b96d22e0a3c336c9174e253fd35e"},
+    {url = "https://files.pythonhosted.org/packages/bf/a8/e4a2e4ef070ad6ba4b79e5a04480ee59301b612968766df936161c96a606/protobuf-4.22.0-cp310-abi3-win32.whl", hash = "sha256:b2fea9dc8e3c0f32c38124790ef16cba2ee0628fe2022a52e435e1117bfef9b1"},
+    {url = "https://files.pythonhosted.org/packages/e1/05/a51b75bdaf32d47a87dd1c57547223f04c72e045bf62dfcecac793f311c3/protobuf-4.22.0-cp37-cp37m-win32.whl", hash = "sha256:1669cb7524221a8e2d9008d0842453dbefdd0fcdd64d67672f657244867635fb"},
+    {url = "https://files.pythonhosted.org/packages/f6/95/797a257a5db4a91dc2bc864c487ead56440014d741933a28c86d966b949e/protobuf-4.22.0.tar.gz", hash = "sha256:652d8dfece122a24d98eebfef30e31e455d300efa41999d1182e015984ac5930"},
 ]
 "psycopg2 2.9.5" = [
     {url = "https://files.pythonhosted.org/packages/04/51/00ed720de223485a56c28b404747b96806679e720f4c97a75bdd556a01f4/psycopg2-2.9.5-cp310-cp310-win32.whl", hash = "sha256:d3ef67e630b0de0779c42912fe2cbae3805ebaba30cda27fea2a3de650a9414f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "tomli>=2.0.1",
     "genson>=1.2.2",
     "sqlglot>=11.2.3",
+    "protobuf>=4.22.0",
 ]
 # < 3.11 for sqlalchemy-bigquery compatibility
 requires-python = ">=3.10, <3.11"

--- a/recap/schema/converters/proto.py
+++ b/recap/schema/converters/proto.py
@@ -1,0 +1,73 @@
+from google.protobuf.descriptor import Descriptor, FieldDescriptor
+
+from recap.schema import model
+
+
+def from_proto(descriptor: Descriptor) -> model.Schema:
+    fields = []
+    for field in descriptor.fields:
+        fields.append(model.Field(name=field.name, schema=_from_proto_field(field)))
+    return model.StructSchema(
+        name=descriptor.name,
+        optional=False,
+        fields=fields,
+    )
+
+
+def _from_proto_field(field: FieldDescriptor) -> model.Schema:
+    match field.type, field.message_type, field.label:
+        case (FieldDescriptor.TYPE_STRING, _, _):
+            schema = model.StringSchema(
+                optional=(field.label == FieldDescriptor.LABEL_OPTIONAL),
+                default=field.default_value,
+            )
+        case (FieldDescriptor.TYPE_BOOL, _, _):
+            schema = model.BooleanSchema(
+                optional=(field.label == FieldDescriptor.LABEL_OPTIONAL),
+                default=field.default_value,
+            )
+        case (FieldDescriptor.TYPE_BYTES, _, _):
+            schema = model.BytesSchema(
+                optional=(field.label == FieldDescriptor.LABEL_OPTIONAL),
+                default=field.default_value,
+            )
+        case (
+            FieldDescriptor.TYPE_DOUBLE | FieldDescriptor.TYPE_FIXED64,
+            _,
+            _,
+        ):
+            schema = model.Float64Schema(
+                optional=(field.label == FieldDescriptor.LABEL_OPTIONAL),
+                default=field.default_value,
+            )
+        case (FieldDescriptor.TYPE_FIXED32 | FieldDescriptor.TYPE_FLOAT, _, _):
+            schema = model.Float32Schema(
+                optional=(field.label == FieldDescriptor.LABEL_OPTIONAL),
+                default=field.default_value,
+            )
+        case (FieldDescriptor.TYPE_INT32, _, _):
+            schema = model.Int32Schema(
+                optional=(field.label == FieldDescriptor.LABEL_OPTIONAL),
+                default=field.default_value,
+            )
+        case (FieldDescriptor.TYPE_INT64 | FieldDescriptor.TYPE_UINT32, _, _):
+            schema = model.Int64Schema(
+                optional=(field.label == FieldDescriptor.LABEL_OPTIONAL),
+                default=field.default_value,
+            )
+        case (FieldDescriptor.TYPE_MESSAGE, Descriptor(), _):
+            schema = from_proto(field.message_type)
+        case _:
+            raise ValueError(
+                "Can't convert to Recap type from JSON schema "
+                f"type={field.type}, label={field.label}"
+            )
+    if field.label == FieldDescriptor.LABEL_REPEATED:
+        schema.optional = False
+        schema.default = None
+        schema = model.ArraySchema(
+            value_schema=schema,
+            optional=(field.label == FieldDescriptor.LABEL_OPTIONAL),
+            default=field.default_value,
+        )
+    return schema

--- a/tests/schema/converters/test_proto.py
+++ b/tests/schema/converters/test_proto.py
@@ -1,0 +1,57 @@
+import pytest
+from google.protobuf import descriptor_pool
+from google.protobuf.descriptor import Descriptor
+
+from recap.schema import model
+from recap.schema.converters.proto import from_proto
+
+DESCRIPTOR = descriptor_pool.Default().AddSerializedFile(
+    b'\n\x11test_models.proto"*\n\x0eSearchResponse\x12\x18\n\x07results\x18\x01 \x03(\x0b\x32\x07.Result"6\n\x06Result\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x01(\t\x12\x10\n\x08snippets\x18\x03 \x03(\tb\x06proto3'
+)
+
+
+class TestProtoConverter:
+    @pytest.fixture
+    def search_response_descriptor(self) -> Descriptor:
+        DESCRIPTOR = descriptor_pool.Default().AddSerializedFile(
+            b'\n\x11test_models.proto"*\n\x0eSearchResponse\x12\x18\n\x07results\x18\x01 \x03(\x0b\x32\x07.Result"6\n\x06Result\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x01(\t\x12\x10\n\x08snippets\x18\x03 \x03(\tb\x06proto3'
+        )
+        """
+        syntax = "proto3";
+
+        message SearchResponse {
+            repeated Result results = 1;
+        }
+
+        message Result {
+            string url = 1;
+            string title = 2;
+            repeated string snippets = 3;
+        }
+        """
+
+        return DESCRIPTOR.message_types_by_name["SearchResponse"]
+
+    def test_search_response(self, search_response_descriptor: Descriptor):
+        recap_schema = from_proto(search_response_descriptor)
+        assert isinstance(recap_schema, model.StructSchema)
+        assert not recap_schema.optional
+        assert recap_schema.name == "SearchResponse"
+        assert len(recap_schema.fields) == 1
+        field = recap_schema.fields[0]
+        assert field.name == "results"
+        assert isinstance(field, model.Field)
+        schema = field.schema_
+        assert isinstance(schema, model.ArraySchema)
+        result_schema = schema.value_schema
+        assert isinstance(result_schema, model.StructSchema)
+        assert len(result_schema.fields) == 3
+        assert result_schema.fields[0].name == "url"
+        assert result_schema.fields[0].schema_ == model.StringSchema(default="")
+        assert result_schema.fields[1].name == "title"
+        assert result_schema.fields[1].schema_ == model.StringSchema(default="")
+        assert result_schema.fields[2].name == "snippets"
+        result_snippets_schema = result_schema.fields[2].schema_
+        assert isinstance(result_snippets_schema, model.ArraySchema)
+        snippet_value_schema = result_snippets_schema.value_schema
+        assert isinstance(snippet_value_schema, model.StringSchema)


### PR DESCRIPTION
I've added *very* basic support for `recap.schema` protocol buffer support. Users can now call `from_proto()` with a `google.proto.descript.Descriptor` and get a Recap schema in response. Many proto features are missing (enums and a lot more), but it's a start.