### PR TITLE
Move away from constraints on base types

### DIFF
--- a/recap/schema/converters/bigquery.py
+++ b/recap/schema/converters/bigquery.py
@@ -24,33 +24,25 @@ def to_recap_schema(columns: list[SchemaField]) -> types.Struct:
                 # TODO Handle BOOL(L)
                 field_type = types.Bool(**schema_args)
             case "DATETIME":
-                field_type = types.Timestamp(
+                field_type = types.Timestamp64(
                     unit=types.TimeUnit.MICROSECOND,
                     **schema_args,
                 )
             case "TIMESTAMP":
-                field_type = types.Timestamp(
+                field_type = types.Timestamp64(
                     timezone="UTC",
                     unit=types.TimeUnit.MICROSECOND,
                     **schema_args,
                 )
             case "TIME":
-                field_type = types.Time(
+                field_type = types.Time64(
                     unit=types.TimeUnit.MICROSECOND,
                     **schema_args,
                 )
             case "DATE":
-                field_type = types.Date(**schema_args)
+                field_type = types.Date64(**schema_args)
             case "INTERVAL":
-                field_type = types.Interval(
-                    # 10000 years in months
-                    months_min=-120_000,
-                    months_max=120_000,
-                    days_min=-3660000,
-                    days_max=3660000,
-                    # 87840000:0:0.0 H:M:S.Mi hours in microseconds
-                    remainder_min=-316224000000000000,
-                    remainder_max=316224000000000000,
+                field_type = types.Interval128(
                     unit=types.TimeUnit.MICROSECOND,
                     **schema_args,
                 )

--- a/recap/schema/converters/frictionless.py
+++ b/recap/schema/converters/frictionless.py
@@ -30,14 +30,6 @@ def to_recap_schema(
                     "Can't convert to Recap type from frictionless "
                     f"type={frictionless_field.type}"
                 )
-        if not frictionless_field.required:
-            field_type = types.Union(
-                types=[
-                    types.Null(),
-                    field_type,
-                ],
-                default=types.DefaultValue(),
-            )
         fields.append(
             types.Field(
                 name=frictionless_field.name,

--- a/recap/schema/converters/sqlalchemy.py
+++ b/recap/schema/converters/sqlalchemy.py
@@ -55,18 +55,24 @@ def to_recap_schema(columns: list[dict[str, Any]]) -> types.Struct:
                 )
             case String() | JSON():
                 field_type = types.String32(**schema_args)
-            case TIMESTAMP() | DATETIME():
-                field_type = types.Timestamp(
+            case TIMESTAMP():
+                field_type = types.Timestamp64(
+                    timezone="UTC",
+                    unit=types.TimeUnit.MICROSECOND,
+                    **schema_args,
+                )
+            case DATETIME():
+                field_type = types.Timestamp64(
                     unit=types.TimeUnit.MICROSECOND,
                     **schema_args,
                 )
             case TIME():
-                field_type = types.Time(
+                field_type = types.Time64(
                     unit=types.TimeUnit.MICROSECOND,
                     **schema_args,
                 )
             case DATE():
-                field_type = types.Date(**schema_args)
+                field_type = types.Date64(**schema_args)
             case _:
                 raise ValueError(
                     "Can't convert to Recap type from SQLAlchemy "

--- a/recap/schema/converters/sqlglot.py
+++ b/recap/schema/converters/sqlglot.py
@@ -54,7 +54,7 @@ def _get_column_defs(
         # TODO Not clear to me whether Duck's TIMESTAMP is actually a DATETIME.
         # TODO Add min/max for timestamp.
         # https://duckdb.org/docs/sql/data_types/timestamp
-        case types.Timestamp(str(unit), timezone=None) if unit in [
+        case types.Timestamp64(str(unit)) if unit in [
             types.TimeUnit.YEAR,
             types.TimeUnit.MONTH,
             types.TimeUnit.DAY,
@@ -65,9 +65,9 @@ def _get_column_defs(
             types.TimeUnit.MICROSECOND,
         ]:
             column_def = "TIMESTAMP"
-        case types.Date():
+        case types.Date64():
             column_def = "DATE"
-        case types.Time():
+        case types.Time64():
             column_def = "TIME"
         # TODO Not clear what Duck's max list length is.
         # TODO Not celar if ARRAY supports ARRAY(n).

--- a/tests/schema/converters/test_avro.py
+++ b/tests/schema/converters/test_avro.py
@@ -175,40 +175,6 @@ class TestAvro:
         )
         assert avsc == expected
 
-    def test_array_default_avro_to_recap(self):
-        avsc = parse(
-            """
-            {
-                "type": "array",
-                "items" : "string",
-                "default": ["a", "b"]
-            }
-            """
-        )
-        array = from_avro(avsc)
-        expected = types.List(
-            values=types.String64(),
-            default=types.DefaultValue(value=["a", "b"]),
-        )
-        assert array == expected
-
-    def test_array_default_recap_to_avro(self):
-        array = types.List(
-            values=types.String64(),
-            default=types.DefaultValue(value=["a", "b"]),
-        )
-        avsc = to_avro(array)
-        expected = parse(
-            """
-            {
-                "type": "array",
-                "items" : "string",
-                "default": ["a", "b"]
-            }
-            """
-        )
-        assert avsc == expected
-
     def test_map_avro_to_recap(self):
         avsc = parse(
             """
@@ -302,16 +268,16 @@ class TestAvro:
         fixed = from_avro(avsc)
         expected = types.Bytes(
             alias="md5",
-            min_length=16,
-            max_length=16,
+            bytes=16,
+            variable=False,
         )
         assert fixed == expected
 
     def test_fixed_recap_to_avro(self):
         fixed = types.Bytes(
             alias="md5",
-            min_length=16,
-            max_length=16,
+            bytes=16,
+            variable=False,
         )
         avsc = to_avro(fixed)
         expected = parse(


### PR DESCRIPTION
I've refactored the schema base types (Int, Float, etc) to use bits instead of min/max as their constraint. Recap is now pretty much fully inline with Arrow's Scheam.fbs and developer types (time32, time64, etc).

I did this because I'm more interested in modeling physical types than logical ones. I care if a float is IEEE encoded vs. arbitrary-precision decimal, for example. It is just more relevant when converting between IDLs and DB schemas.