### PR TITLE
Add a Recap schema definition language

### DIFF
--- a/recap/schema/converters/json_schema.py
+++ b/recap/schema/converters/json_schema.py
@@ -68,7 +68,6 @@ def from_json_schema(json_schema: dict[str, Any]) -> types.Type:
                     )
                 )
             return types.Struct(
-                name=json_schema.get("title"),
                 doc=json_schema.get("description"),
                 fields=fields,
                 **schema_args,
@@ -91,7 +90,7 @@ def to_json_schema(
     json_schema_ver: str | None = DEFAULT_SCHEMA_VERSION,
 ) -> dict[str, Any]:
     json_schema = {}
-    if isinstance(schema, types.Struct) or isinstance(schema, types.Field):
+    if isinstance(schema, types.Field):
         json_schema["title"] = schema.name
     if schema.doc:
         json_schema["description"] = schema.doc

--- a/recap/schema/converters/proto.py
+++ b/recap/schema/converters/proto.py
@@ -13,7 +13,6 @@ def from_proto(descriptor: Descriptor) -> types.Struct:
             struct_field,
         )
     return types.Struct(
-        name=descriptor.name,
         fields=struct_fields,
     )
 

--- a/recap/schema/converters/sdl.py
+++ b/recap/schema/converters/sdl.py
@@ -1,0 +1,84 @@
+from typing import Any
+
+from recap.schema import types
+
+ALIASES = {
+    "int8": types.Int8(),
+    "uint8": types.Uint8(),
+    "int16": types.Int16(),
+    "uint16": types.Uint16(),
+    "int32": types.Int32(),
+    "uint32": types.Uint32(),
+    "int64": types.Int64(),
+    "uint64": types.Uint64(),
+    "float16": types.Float16(),
+    "float32": types.Float32(),
+    "float64": types.Float64(),
+}
+
+
+def to_recap_schema(
+    sdl_type: dict[str, Any] | list | str,
+    aliases: dict[str, types.Type] | None = None,
+) -> types.Type:
+    aliases = aliases or ALIASES
+    match sdl_type:
+        case {"type": "int", **rest}:
+            return types.Int(
+                bits=sdl_type["bits"],
+                signed=sdl_type.get("signed", True),
+            )
+        case {"type": "float", **rest}:
+            return types.Float(bits=sdl_type["bits"])
+        case {"type": "string", **rest}:
+            return types.String(
+                bytes=sdl_type["bytes"],
+                variable=sdl_type.get("variable", True),
+            )
+        case {"type": "bytes", **rest}:
+            return types.Bytes(
+                bytes=sdl_type["bytes"],
+                variable=sdl_type.get("variable", True),
+            )
+        case {"type": "list", **rest}:
+            return types.List(
+                values=to_recap_schema(sdl_type["values"]),
+                bits=sdl_type.get("bits"),
+            )
+        case {"type": "map", **rest}:
+            return types.Map(
+                keys=to_recap_schema(sdl_type["keys"]),
+                values=to_recap_schema(sdl_type["values"]),
+            )
+        case {"type": "struct", **rest}:
+            return types.Struct(
+                fields=[
+                    types.Field(
+                        name=field.get("name"),
+                        type_=to_recap_schema(field),
+                        default=(
+                            types.DefaultValue(value=field["default"])
+                            if "default" in field
+                            else None
+                        ),
+                    )
+                    for field in sdl_type.get("fields", [])
+                ]
+            )
+        case {"type": "enum", **rest}:
+            return types.Enum(
+                symbols=sdl_type["symbols"],
+            )
+        case list():
+            # Treat the type as a union.
+            return types.Union(
+                types=[to_recap_schema(union_type) for union_type in sdl_type]
+            )
+        case {"type": alias, **rest} if alias in aliases:
+            # Treat the type as an alias.
+            return aliases[alias]
+        case str(alias) if alias in aliases:
+            # Treat the type as an alias.
+            return aliases[alias]
+        case type:
+            raise ValueError(f"Can't parse Recap SDL for type={type}")

--- a/recap/schema/types.py
+++ b/recap/schema/types.py
@@ -76,11 +76,9 @@ class Map(Type):
 
 class Struct(Type):
     fields: list[Field] = []
-    name: str | None = None
 
     # TODO This is certainly wrong.
     # Needs tests.
-    # Do we check struct name as part of equality?
     # Do we check field defaults as part of equality?
     # We probably care about field ordering here, too.
     def subsumes(self, other: Type) -> bool:

--- a/tests/schema/converters/test_proto.py
+++ b/tests/schema/converters/test_proto.py
@@ -31,7 +31,6 @@ class TestProtoConverter:
     def test_search_response(self, search_response_descriptor: Descriptor):
         recap_schema = from_proto(search_response_descriptor)
         assert isinstance(recap_schema, types.Struct)
-        assert recap_schema.name == "SearchResponse"
         assert len(recap_schema.fields) == 1
         field = recap_schema.fields[0]
         assert field.name == "results"

--- a/tests/schema/converters/test_sdl.py
+++ b/tests/schema/converters/test_sdl.py
@@ -1,0 +1,43 @@
+from recap.schema import types
+from recap.schema.converters.sdl import to_recap_schema
+
+
+class TestSdl:
+    def test_basic_sdl_to_recap(self):
+        sdl = {
+            "type": "struct",
+            "fields": [
+                {
+                    "type": "int32",
+                },
+            ],
+        }
+        struct = to_recap_schema(sdl)
+        expected = types.Struct(
+            fields=[
+                types.Field(type_=types.Int32()),
+            ],
+        )
+        assert struct == expected
+
+    def test_list_sdl_to_recap(self):
+        sdl = {
+            "type": "struct",
+            "fields": [
+                {
+                    "type": "list",
+                    "values": "int32",
+                },
+            ],
+        }
+        struct = to_recap_schema(sdl)
+        expected = types.Struct(
+            fields=[
+                types.Field(
+                    type_=types.List(
+                        values=types.Int32(),
+                    )
+                ),
+            ],
+        )
+        assert struct == expected


### PR DESCRIPTION
I'm starting to codify the Recap type system into an object-based schema definition language.

By "object based", I mean it's using standard in-memory objects (dict, list, str, int, float) instead of a text-based SDL (think TOML, YAML, JSON, etc). It's agnostic to the SDL serialization format. It's also not directly using Recap's in-memory `Type` types because they are less human-friendly to write.

This is all laying the groundwork for a three tier architecture:

1. Recap types (`types.Bytes()`)
2. Recap in-memory schema objects (`{"type": "bytes", ...}`)
3. Recap serialized schema objects (TOML, JSON, YAML, etc)

The schema registry will use (3), probably with JSON.