### PR TITLE
Add UUID type to spec

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -24,6 +24,8 @@ Recap supports the following types:
 * `enum`
 * `union`
 
+Note: These types are inspired by [Apache Arrow's Schema.fbs](https://github.com/apache/arrow/blob/main/format/Schema.fbs).
+
 ### `null`
 
 A null value.
@@ -225,74 +227,7 @@ All types support an `alias` attribute. `alias` allows a type to reference previ
 
 * `alias`: An alias for the type. (type: string32 | null, required: false, default: null)
 
-### References
-
-Aliases are referenced using the `type` field:
-
-```yaml
-type: struct
-doc: A chapter in a book
-fields:
-    - name: previous
-      alias: Page
-      type: int
-      bits: 32
-      signed: false
-    - name: next
-      type: Page
-```
-
-In this example, `next`'s type will be the same as `previous`'s.
-
-Recap also allows cyclic references:
-
-```yaml
-alias: LinkedListUint32
-type: struct
-doc: A linked list of unsigned 32-bit integers
-fields:
-    - name: value
-      type: int
-      bits: 32
-      signed: false
-    - name: next
-      type: LinkedListUint32
-```
-
-### Additional Attributes
-
-Aliases may define additional required or optional attributes.
-
-### Logical Types
-
-Aliases may carry semantinc meaning. For example, a UTC `timestamp64` is defined as:
-
-```yaml
-type: int
-bits: 64
-signed: true
-timezone: UTC
-```
-
-But without the `alias` set to `timestamp64`, the `timezone` attribute will be ignored and the type will be treated as a normal 64 bit signed integer.
-
-### Nested References
-
-Type aliases can references other type aliases, too:
-
-```yaml
-type: ParentType
-alias: NestedType
-color: blue
-```
-
-Nested types with attributes will overwrite any defined attributes with the same name in the parent type. In this example, `NestedType`'s `color: blue` overwrites any `color` defined in `ParentType`.
-
-### Namespaces
-
-Aliases are globally unique, so they must include a unique dotted namespace prefix. Naked aliases (aliases with no dotted namespace) are reserved for Recap.
-
-## Built-in Aliases
+### Built-in Aliases
 
 Recap includes the following built-in type aliases:
 
@@ -311,6 +246,7 @@ Recap includes the following built-in type aliases:
 * `string64`
 * `bytes32`
 * `bytes64`
+* `uuid`
 * `decimal`
 * `decimal128`
 * `decimal256`
@@ -322,9 +258,9 @@ Recap includes the following built-in type aliases:
 * `date32`
 * `date64`
 
-### `int8`
+#### `int8`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int
@@ -332,9 +268,9 @@ alias: int8
 bits: 8
 ```
 
-### `uint8`
+#### `uint8`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int
@@ -343,9 +279,9 @@ bits: 8
 signed: false
 ```
 
-### `int16`
+#### `int16`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int
@@ -353,9 +289,9 @@ alias: int16
 bits: 16
 ```
 
-### `uint16`
+#### `uint16`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int
@@ -364,9 +300,9 @@ bits: 16
 signed: false
 ```
 
-### `int32`
+#### `int32`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int
@@ -374,9 +310,9 @@ alias: int32
 bits: 32
 ```
 
-### `uint32`
+#### `uint32`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int
@@ -385,9 +321,9 @@ bits: 32
 signed: false
 ```
 
-### `int64`
+#### `int64`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int
@@ -395,9 +331,9 @@ alias: int64
 bits: 64
 ```
 
-### `uint64`
+#### `uint64`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int
@@ -406,9 +342,9 @@ bits: 64
 signed: false
 ```
 
-### `float16`
+#### `float16`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: float
@@ -416,9 +352,9 @@ alias: float16
 bits: 16
 ```
 
-### `float32`
+#### `float32`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: float
@@ -426,9 +362,9 @@ alias: float32
 bits: 32
 ```
 
-### `float64`
+#### `float64`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: float
@@ -436,9 +372,9 @@ alias: float64
 bits: 64
 ```
 
-### `bytes32`
+#### `bytes32`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: bytes
@@ -446,9 +382,9 @@ alias: bytes32
 bytes: 2_147_483_647
 ```
 
-### `bytes64`
+#### `bytes64`
 
-#### Definition
+##### Definition
 
 ```yaml
 type: bytes
@@ -456,32 +392,45 @@ alias: bytes64
 bytes: 9_223_372_036_854_775_807
 ```
 
-### `decimal`
+#### `uuid`
 
-An arbitrary-precsion decimal number.
+A UUID in 8-4-4-4-12 string format (XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX) as defined in [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt). 
 
-#### Attributes
+##### Definition
+
+```yaml
+type: string
+alias: uuid
+bytes: 36
+variable: false
+```
+
+#### `decimal`
+
+An arbitrary-precsion decimal number. This type is the same as [Avro's Decimal](https://avro.apache.org/docs/1.10.2/spec.html#Decimal).
+
+##### Attributes
 
 * `precision`: Total number of digits. 123.456 has a precision of 6. (type: int, required: true)
 * `scale`: Digits to the right of the decimal point. 123.456 has a scale of 3. (type: int, required: true)
 
-#### Definition
+##### Definition
 
 ```yaml
 type: bytes32
 alias: decimal
 ```
 
-### `decimal128`
+#### `decimal128`
 
-An arbitrary-precsion decimal number stored in a fixed length 128-bit byte array.
+An arbitrary-precsion decimal number stored in a fixed length 128-bit byte array. This type is the same as [Arrow's decimal128](https://arrow.apache.org/docs/python/generated/pyarrow.decimal128.html#pyarrow.decimal128).
 
-#### Attributes
+##### Attributes
 
 * `precision`: Total number of digits. 123.456 has a precision of 6. (type: int, required: true)
 * `scale`: Digits to the right of the decimal point. 123.456 has a scale of 3. (type: int, required: true)
 
-#### Definition
+##### Definition
 
 ```yaml
 type: bytes
@@ -490,16 +439,16 @@ bytes: 16
 variable: false
 ```
 
-### `decimal256`
+#### `decimal256`
 
-An arbitrary-precsion decimal number stored in a fixed length 256-bit byte array.
+An arbitrary-precsion decimal number stored in a fixed length 256-bit byte array. This type is the same as [Arrow's decimal256](https://arrow.apache.org/docs/r/reference/data-type.html).
 
-#### Attributes
+##### Attributes
 
 * `precision`: Total number of digits. 123.456 has a precision of 6. (type: int, required: true)
 * `scale`: Digits to the right of the decimal point. 123.456 has a scale of 3. (type: int, required: true)
 
-#### Definition
+##### Definition
 
 ```yaml
 type: bytes
@@ -508,32 +457,34 @@ bytes: 32
 variable: false
 ```
 
-### `duration64`
+#### `duration64`
 
-A length of time without timezones and leap seconds.
+A length of time without timezones and leap seconds. This type is the same as [Arrow's Duration](https://arrow.apache.org/docs/python/generated/pyarrow.duration.html) but with a superset of time units.
 
-#### Attributes
+##### Attributes
 
-* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string, required: true)
+* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string32, required: true)
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int64
 alias: duration64
 ```
 
-### `interval128`
+#### `interval128`
 
 An interval of time on a calendar. This measurement allows you to measure time without worrying about leap seconds, leap years, and time changes. Years, quarters, hours, and minutes can be expressed using this type.
 
 The interval is measured in months, days, and an intra-day time measurement. Months and days are each 32-bit signed integers. The remainder is a 64-bit signed integer measured in a certain time unit. Leap seconds are ignored.
 
-#### Attributes
+This type is the same as [Arrow's month_day_nano_interval](https://arrow.apache.org/docs/python/generated/pyarrow.month_day_nano_interval.html) but with a superset of time units.
 
-* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string, required: true)
+##### Attributes
 
-#### Definition
+* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string32, required: true)
+
+##### Definition
 
 ```yaml
 type: bytes
@@ -542,37 +493,37 @@ bytes: 16
 variable: false
 ```
 
-### `time32`
+#### `time32`
 
-Time since midnight without timezones and leap seconds in a 32-bit integer.
+Time since midnight without timezones and leap seconds in a 32-bit integer. This type is the same as [Arrow's time32](https://arrow.apache.org/docs/python/generated/pyarrow.time32.html) but with a superset of time units.
 
-#### Attributes
+##### Attributes
 
-* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string, required: true)
+* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string32, required: true)
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int32
 alias: time32
 ```
 
-### `time64`
+#### `time64`
 
-Time since midnight without timezones and leap seconds in a 64-bit integer.
+Time since midnight without timezones and leap seconds in a 64-bit integer. This type is the same as [Arrow's time64](https://arrow.apache.org/docs/python/generated/pyarrow.time64.html) but with a superset of time units.
 
-#### Attributes
+##### Attributes
 
-* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string, required: true)
+* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string32, required: true)
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int64
 alias: time64
 ```
 
-### `timestamp64`
+#### `timestamp64`
 
 Time elapsed since a specific epoch.
 
@@ -580,47 +531,114 @@ A timestamp with no timezone is a `datetime` in database parlance--a date and ti
 
 A timestamp with a timezone represents the amount of time elapsed since the 1970-01-01 00:00:00 epoch in UTC time zone (regardless of the timezone that's specified). Readers most translate the UTC timetsamp to a timestamp value for the specified timezone. See Apache Arrow's [Schema.fbs](https://github.com/apache/arrow/blob/main/format/Schema.fbs) documentation for more details.
 
-#### Attributes
+This type is the same as [Arrow's timestamp](https://arrow.apache.org/docs/python/generated/pyarrow.timestamp.html) but with a superset of time units.
 
-* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string, required: true)
-* `timezone`: An optional `Olson timezone database` string. (type: string | null, required: false, default: null)
+##### Attributes
 
-#### Definition
+* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string32, required: true)
+* `timezone`: An optional `Olson timezone database` string. (type: string32 | null, required: false, default: null)
+
+##### Definition
 
 ```yaml
 type: int64
 alias: timetamp64
 ```
 
-### `date32`
+#### `date32`
 
-Date since the UNIX epoch without timezones and leap seconds in a 32-bit integer.
+Date since the UNIX epoch without timezones and leap seconds in a 32-bit integer. This type is the same as [Arrow's date32](https://arrow.apache.org/docs/python/generated/pyarrow.date32.html) but with a superset of time units.
 
-#### Attributes
+##### Attributes
 
-* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string, required: true)
+* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string32, required: true)
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int32
 alias: date32
 ```
 
-### `date64`
+#### `date64`
 
-Date since the UNIX epoch without timezones and leap seconds in a 64-bit integer.
+Date since the UNIX epoch without timezones and leap seconds in a 64-bit integer. This type is the same as [Arrow's date64](https://arrow.apache.org/docs/python/generated/pyarrow.date64.html) but with a superset of time units.
 
-#### Attributes
+##### Attributes
 
-* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string, required: true)
+* `unit`: A string time unit: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, or PICOSECOND (type: string32, required: true)
 
-#### Definition
+##### Definition
 
 ```yaml
 type: int64
 alias: date64
 ```
+
+### References
+
+Aliases are referenced using the `type` field:
+
+```yaml
+type: struct
+doc: A chapter in a book
+fields:
+    - name: previous
+      alias: com.mycorp.models.Page
+      type: int
+      bits: 32
+      signed: false
+    - name: next
+      type: com.mycorp.models.Page
+```
+
+In this example, `next`'s type will be the same as `previous`'s.
+
+Recap also allows cyclic references:
+
+```yaml
+alias: com.mycorp.models.LinkedListUint32
+type: struct
+doc: A linked list of unsigned 32-bit integers
+fields:
+    - name: value
+      type: int
+      bits: 32
+      signed: false
+    - name: next
+      type: com.mycorp.models.LinkedListUint32
+```
+
+### Additional Attributes
+
+Aliases may define additional required or optional attributes.
+
+### Logical Types
+
+Aliases may carry semantinc meaning. For example, a UTC `timestamp64` is defined as:
+
+```yaml
+type: int64
+timezone: UTC
+```
+
+But without the `type` set to `timestamp64`, the `timezone` attribute will be ignored and the type will be treated as a normal 64-bit signed integer.
+
+### Nested References
+
+Type aliases can extend other type aliases, too:
+
+```yaml
+type: com.mycorp.models.ParentType
+alias: com.mycorp.models.NestedType
+color: blue
+```
+
+Nested types with attributes will overwrite any defined attributes with the same name in the parent type. In this example, `NestedType`'s `color: blue` overwrites any `color` defined in `ParentType`.
+
+### Namespaces
+
+Aliases are globally unique, so they must include a unique dotted namespace prefix. Naked aliases (aliases with no dotted namespace) are reserved for Recap.
 
 ## FAQ
 
@@ -652,22 +670,22 @@ I couldn't find a good reason to. The common bit lengths are implemented as alia
 
 ### Why is it called a `struct`?
 
-Struct, record, schema, and object are all common. A `schema` containting a `schema` is strange and `objects` normally have methods. A `record` could have worked, but seemed less well known. Thus, I went with `struct`.
+Struct, record, schema, and object are all common. A "schema" containting a "schema" is strange and "objects" usually have methods. "record" could have worked, but seemed less well known. Thus, I went with "struct".
 
 ### Why didn't you use a more expressive type system like CUE?
 
-Frankly, I'm not an academic and I don't have enough specialty in type systems to contribute to that area. I did spend time with CUE (and a little with KCL), and found them to be unwieldy. I didn't want templating and the set of constraints that I want to include in Recap is modest. Elaborate type systems and templating felt like overkill.
+Frankly, I'm not an academic and I don't have enough specialty in type systems to contribute to that area. I did spend time with CUE (and a little with KCL), and found them to be unwieldy. I didn't want templating, and I only want to include a small set of constraints in Recap. Elaborate type systems and templating felt like overkill.
 
 Kafka Connect is an schema example that is much more constrained than something like CUE, while still modeling most of what Recap wants to model. Kafka Connect has [hundreds of source and sink connectors](https://docs.confluent.io/cloud/current/connectors/index.html#preview-connectors).
 
-Apache Arrow is in the same vein as Kafka Connect. In fact, Recap's base types and many of its `alias`es are taken directly from Apache Arrow.
+[Apache Arrow](https://arrow.apache.org) is in the same vein as Kafka Connect. In fact, Recap's base types and many of its `alias`es are taken directly from Apache Arrow. Again, Arrow has proven to work with dozens of different databases and data frameworks.
 
 ### So, why didn't you use Apache Arrow?
 
 For starters, Arrow doesn't have a schema definition language; it's entirely programmatic. Their spec is their [Schema.fbs](https://github.com/apache/arrow/blob/main/format/Schema.fbs). You'd have to write code to define a schema; this isn't what I wanted.
 
-In addition, their in-memory model is more optimized for columnar analytical work. Recap's main focus is on record-based data from APIs, message buses, and databases. Single record operations tend to be different than analytical ones. Counting and grouping doesn't make much sense on a single record. Schema manipulation is where Recap focuses: projecting out fields, merging and intersecting schemas, and checking for schema compatibility; that's where Recap shines.
+In addition, their in-memory model is more optimized for columnar analytical work. Recap's main focus is on record-based data from APIs, message buses, and databases. Single record operations and schema manipulation tend to be different than analytical operations. Counting and grouping doesn't make much sense on a single record. Schema manipulation is where Recap shines: projecting out fields, merging and intersecting schemas, and checking for schema compatibility.
 
 ### How do you handle coercion?
 
-Coercing types that don't fit cleanly into Recap's type system is outside the scope of this spec. Recap will include a test suite that defines how specific types are meant to be converted to and from Recap types on a per-SDL basis. For example, converting PostgreSQL's `uuid` type to/from a Recap type is something that will be defined in the test suite and documented in the PostgreSQL converter documentation.
+Coercing types that don't fit cleanly into Recap's type system is outside the scope of this spec. Recap will include a test suite that defines how specific types are meant to be converted to and from Recap types on a per-SDL basis. For example, converting PostgreSQL's `geography(point)` type to/from a Recap type is something that will be defined in the test suite and documented in the PostgreSQL converter documentation.


### PR DESCRIPTION
I've added a UUID derived type to the spec because it's a common enough type.

I also re-ordered the alias section to lead with the built-in's since I think they clarify the `alias` use case well.

Fixed some typos as well, and added some outside link references for Arrow and Avro.