### PR TITLE
Add `nullable` to Recap spec

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -159,16 +159,18 @@ A field can be any recap type. Fields have the following additional attributes:
 
 * `name`: The field's name. (type: string32 | null, required: false, default: null)
 * `default`: The default value for a reader if the field is not set in the struct. (type: literal, required: false)
+* `nullable`: If true, the field's value must be set. `nullable=false` is syntactic sugar that wraps the field's type in a union of `types=[null, type]` with a `null` default (if default is not explicitly defined). (type: bool, required: false, default: true)
 
 #### Examples
 
 ```yaml
-# A struct with a single signed 32-bit integer field called "id"
+# A struct with a required signed 32-bit integer field called "id"
 type: struct
 fields:
     - name: id
       type: int
       bits: 32
+      nullable: false
 ```
 
 ### `enum`


### PR DESCRIPTION
I decided to add a `nullable` to Recap's struct fields. This mirrors Arrow's `field` table in Schema.fbs, but moves Recap's type system away from Avro's null modeling (union with defaults). `nullable` is just too ergonomic for developers to ignore. Recap should support it even if it is just syntactic sugar.