### PR TITLE
Add `diff` helper to `recap.schema`

### DIFF
--- a/recap/schema/__init__.py
+++ b/recap/schema/__init__.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from recap.schema.converters.converter import Converter
+from recap.schema.diff import diff as obj_diff
 
 
 def convert(
@@ -10,8 +11,6 @@ def convert(
     **schema_args,
 ):
     match from_type, to_type:
-        case "recap", "recap":
-            raise ValueError("Please set `from_type` or `to_type` argument.")
         case "recap", str(to_type):
             return Converter.get_converter(to_type).from_recap_type(
                 schema_obj,
@@ -36,3 +35,18 @@ def convert(
             raise ValueError(
                 f"Got unknown from_type=`{from_type}` or to_type=`{to_type}`."
             )
+
+
+def diff(
+    schema_obj_a: Any,
+    schema_obj_b: Any,
+    obj_a_type: str,
+    obj_b_type: str,
+):
+    # Convert to Recap types since diff'ing requires it.
+    type_a = convert(schema_obj_a, from_type=obj_a_type)
+    type_b = convert(schema_obj_b, from_type=obj_b_type)
+    # Convert Recap types to Recap type objects.
+    type_obj_a = convert(type_a, to_type="recap")
+    type_obj_b = convert(type_b, to_type="recap")
+    return obj_diff(type_obj_a, type_obj_b)


### PR DESCRIPTION
I've added a helper that takes schema objects (Avro, Proto, etc) rather than Recap type objects. Internally, it still converts to Recap type objects to use with `recap.schema.diff`, but it's a little more convenient.