### PR TITLE
Support Python 3.11

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -64,6 +64,7 @@ dependencies = [
     "lazy-object-proxy>=1.4.0",
     "typing-extensions>=4.0.0; python_version < \"3.11\"",
     "wrapt<2,>=1.11; python_version < \"3.11\"",
+    "wrapt<2,>=1.14; python_version >= \"3.11\"",
 ]
 
 [[package]]
@@ -347,7 +348,9 @@ summary = "Google API client core library"
 dependencies = [
     "google-api-core==2.11.0",
     "grpcio-status<2.0dev,>=1.33.2",
+    "grpcio-status<2.0dev,>=1.49.1; python_version >= \"3.11\"",
     "grpcio<2.0dev,>=1.33.2",
+    "grpcio<2.0dev,>=1.49.1; python_version >= \"3.11\"",
 ]
 
 [[package]]
@@ -382,6 +385,7 @@ dependencies = [
     "google-cloud-core<3.0.0dev,>=1.6.0",
     "google-resumable-media<3.0dev,>=0.6.0",
     "grpcio<2.0dev,>=1.47.0",
+    "grpcio<2.0dev,>=1.49.1; python_version >= \"3.11\"",
     "packaging>=20.0.0",
     "proto-plus<2.0.0dev,>=1.15.0",
     "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
@@ -397,6 +401,7 @@ summary = "Google Cloud Bigquery Storage API client library"
 dependencies = [
     "google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0",
     "proto-plus<2.0.0dev,>=1.22.0",
+    "proto-plus<2.0.0dev,>=1.22.2; python_version >= \"3.11\"",
     "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
 ]
 
@@ -794,6 +799,7 @@ requires_python = ">=3.8"
 summary = "Powerful data structures for data analysis, time series, and statistics"
 dependencies = [
     "numpy>=1.21.0; python_version >= \"3.10\"",
+    "numpy>=1.23.2; python_version >= \"3.11\"",
     "python-dateutil>=2.8.1",
     "pytz>=2020.1",
 ]
@@ -918,6 +924,7 @@ dependencies = [
     "astroid<=2.16.0-dev0,>=2.14.1",
     "colorama>=0.4.5; sys_platform == \"win32\"",
     "dill>=0.2; python_version < \"3.11\"",
+    "dill>=0.3.6; python_version >= \"3.11\"",
     "isort<6,>=4.2.5",
     "mccabe<0.8,>=0.6",
     "platformdirs>=2.2.0",
@@ -1346,7 +1353,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:874364bc652eab6e7c5e68fb0975e7356c68c1f36739dcdd8273044ffdbc0cc4"
+content_hash = "sha256:6fe379578ad95dc4b3a868d3ce6b0f32e2a5e32adcfb1f65460b7366910374b2"
 
 [metadata.files]
 "aiobotocore 2.4.2" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ dependencies = [
     "sqlglot>=11.3.6",
     "protobuf>=4.22.1",
 ]
-# < 3.11 for sqlalchemy-bigquery compatibility
-requires-python = ">=3.10, <3.11"
+# < 3.12 for sqlalchemy-bigquery
+requires-python = ">=3.10, <3.12"
 readme = "README.md"
 license = {text = "MIT"}
 keywords = [
@@ -50,7 +50,7 @@ recap = "recap.cli:app"
 [project.optional-dependencies]
 gcp = [
     "gcsfs>=2023.1.0",
-    "sqlalchemy-bigquery>=1.5.0",
+    "sqlalchemy-bigquery>=1.6.1",
 ]
 
 [build-system]
@@ -68,7 +68,7 @@ docs = [
 dbs = [
     "psycopg2>=2.9.5",
     "snowflake-sqlalchemy>=1.4.4",
-    "sqlalchemy-bigquery>=1.5.0",
+    "sqlalchemy-bigquery>=1.6.1",
     "google-cloud-bigquery>=3.6.0",
 ]
 fss = [

--- a/recap/readers/sqlalchemy.py
+++ b/recap/readers/sqlalchemy.py
@@ -21,6 +21,10 @@ from recap.readers.readers import functions
 
 
 @functions.schema(
+    "bigquery://{database}/{schema}/{table}",
+    include_engine=True,
+)
+@functions.schema(
     "postgresql://{netloc}/{database}/{schema}/{table}",
     include_engine=True,
 )
@@ -50,6 +54,8 @@ def schema(
     return SQLAlchemyConverter().to_recap_type(columns)
 
 
+@functions.ls("bigquery://{database}/{schema}", include_engine=True)
+@functions.ls("bigquery://{database}/", include_engine=True)
 @functions.ls("postgresql://{netloc}/{database}", include_engine=True)
 @functions.ls("postgresql://{netloc}/{database}/{schema}", include_engine=True)
 @functions.ls("snowflake://{netloc}/{database}", include_engine=True)


### PR DESCRIPTION
BigQuery's SQLAlchemy driver was blocking 3.11 support. They've updated their setup.py now, so Recap can support 3.12. I've updated the pyproject.toml accordingly.

I've also re-added BigQuery URLs to the sqlalchemy.py reader. I previously had a BigQuery reader, but I've removed it to simply things (for now). The converter still exists, but isn't being used.

Closes #195