### PR TITLE
Add a Java library for Recap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,9 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  test-python:
     runs-on: ubuntu-latest
+
     defaults:
       run:
         working-directory: python
@@ -20,6 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Build using Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -52,3 +54,28 @@ jobs:
       run: |
         source venv/bin/activate
         pdm run pytest
+
+  test-java:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: java
+
+    strategy:
+      matrix:
+        java-version: ['11']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java-version }}
+
+    - name: Build
+      run: mvn -B clean package
+
+    - name: Run tests
+      run: mvn test

--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,0 +1,35 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>build.recap</groupId>
+    <artifactId>recap</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>recap-core</module>
+        <module>recap-kafka</module>
+    </modules>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-api</artifactId>
+                <version>3.4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>build.recap</groupId>
+                <artifactId>recap-core</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/java/recap-core/pom.xml
+++ b/java/recap-core/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>build.recap</groupId>
+        <artifactId>recap</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.json.bind</groupId>
+            <artifactId>javax.json.bind-api</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <version>1.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <artifactId>recap-core</artifactId>
+</project>

--- a/java/recap-core/src/main/java/build/recap/Client.java
+++ b/java/recap-core/src/main/java/build/recap/Client.java
@@ -1,0 +1,38 @@
+package build.recap;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+public class Client {
+    private HttpClient httpClient;
+
+    public Client() {
+        this(HttpClient.newHttpClient());
+    }
+
+    public Client(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public HttpResponse<String> post(String url, Type type) throws Exception {
+        URI uri = URI.create(url);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(type)))
+                .build();
+
+        return httpClient.send(request, BodyHandlers.ofString());
+    }
+
+    private String toJson(Type type) throws Exception {
+        try (Jsonb jsonb = JsonbBuilder.create()) {
+            return jsonb.toJson(type.toTypeDescription());
+        }
+    }
+}

--- a/java/recap-core/src/main/java/build/recap/Data.java
+++ b/java/recap-core/src/main/java/build/recap/Data.java
@@ -1,0 +1,42 @@
+package build.recap;
+
+import java.util.Objects;
+
+public class Data {
+    private final Type type;
+    private final Object object;
+
+    public Data(Type type, Object object) {
+        this.type = type;
+        this.object = object;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Object getObject() {
+        return object;
+    }
+
+    @Override
+    public String toString() {
+        return "Data{" +
+                "type=" + type +
+                ", object=" + object +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Data data = (Data) o;
+        return Objects.equals(type, data.type) && Objects.equals(object, data.object);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, object);
+    }
+}

--- a/java/recap-core/src/main/java/build/recap/Type.java
+++ b/java/recap-core/src/main/java/build/recap/Type.java
@@ -1,0 +1,613 @@
+package build.recap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class Type {
+    // TODO: Add alias support
+    protected String logicalType;
+    protected String docString;
+    protected Map<String, Object> extraAttributes;
+
+    public Type() {
+        this(null, null, null);
+    }
+
+    public Type(String logicalType, String docString, Map<String, Object> extraAttributes) {
+        this.logicalType = logicalType;
+        this.docString = docString;
+        this.extraAttributes = extraAttributes != null ? new HashMap<>(extraAttributes) : new HashMap<>();
+    }
+
+    public String getLogicalType() {
+        return logicalType;
+    }
+
+    public String getDocString() {
+        return docString;
+    }
+
+    public Map<String, Object> getExtraAttributes() {
+        return extraAttributes;
+    }
+
+    public Map<String, Object> toTypeDescription() {
+        Map<String, Object> typeDescription = new HashMap<>();
+        if (logicalType != null) {
+            typeDescription.put("logical", logicalType);
+        }
+        if (docString != null) {
+            typeDescription.put("doc", docString);
+        }
+        typeDescription.putAll(extraAttributes);
+        return typeDescription;
+    }
+
+    @Override
+    public String toString() {
+        return "Type{" +
+                "logicalType='" + logicalType + '\'' +
+                ", docString='" + docString + '\'' +
+                ", extraAttributes=" + extraAttributes +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Type type = (Type) o;
+        return Objects.equals(logicalType, type.logicalType) && Objects.equals(docString, type.docString) && Objects.equals(extraAttributes, type.extraAttributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(logicalType, docString, extraAttributes);
+    }
+
+    public static class Bool extends Type {
+        public Bool() {
+            this(null, null, null);
+        }
+
+        public Bool(String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.put("type", "bool");
+            return typeDescription;
+        }
+    }
+
+    public static class Null extends Type {
+        public Null() {
+            this(null, null, null);
+        }
+
+        public Null(String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.put("type", "null");
+            return typeDescription;
+        }
+    }
+
+    public static class Int extends Type {
+        private final int bits;
+        private final boolean signed;
+
+        public Int(int bits, boolean signed) {
+            this(bits, signed, null, null, null);
+        }
+
+        public Int(int bits, boolean signed, String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+            this.bits = bits;
+            this.signed = signed;
+        }
+
+        public int getBits() {
+            return bits;
+        }
+
+        public boolean isSigned() {
+            return signed;
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.putAll(Map.of(
+                    "type", "int",
+                    "bits", bits,
+                    "signed", signed
+            ));
+            return typeDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "Int{" +
+                    "bits=" + bits +
+                    ", signed=" + signed +
+                    ", logicalType='" + logicalType + '\'' +
+                    ", docString='" + docString + '\'' +
+                    ", extraAttributes=" + extraAttributes +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Int anInt = (Int) o;
+            return bits == anInt.bits && signed == anInt.signed;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), bits, signed);
+        }
+    }
+
+    public static class Float extends Type {
+        private final int bits;
+
+        public Float(int bits) {
+            this(bits, null, null, null);
+        }
+
+        public Float(int bits, String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+            this.bits = bits;
+        }
+
+        public int getBits() {
+            return bits;
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.putAll(Map.of(
+                    "type", "float",
+                    "bits", bits
+            ));
+            return typeDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "Float{" +
+                    "bits=" + bits +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Float aFloat = (Float) o;
+            return bits == aFloat.bits;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), bits);
+        }
+    }
+
+    public static class String_ extends Type {
+        private final long bytes;
+        private final boolean variable;
+
+        public String_(long bytes, boolean variable) {
+            this(bytes, variable, null, null, null);
+        }
+
+        public String_(long bytes, boolean variable, String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+            this.bytes = bytes;
+            this.variable = variable;
+        }
+
+        public long getBytes() {
+            return bytes;
+        }
+
+        public boolean isVariable() {
+            return variable;
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.putAll(Map.of(
+                    "type", "string",
+                    "bytes", bytes,
+                    "variable", variable
+            ));
+            return typeDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "String_{" +
+                    "bytes=" + bytes +
+                    ", variable=" + variable +
+                    ", logicalType='" + logicalType + '\'' +
+                    ", docString='" + docString + '\'' +
+                    ", extraAttributes=" + extraAttributes +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            String_ string = (String_) o;
+            return bytes == string.bytes && variable == string.variable;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), bytes, variable);
+        }
+    }
+
+    public static class Bytes extends Type {
+        private final long bytes;
+        private final boolean variable;
+
+        public Bytes(long bytes, boolean variable) {
+            this(bytes, variable, null, null, null);
+        }
+
+        public Bytes(long bytes, boolean variable, String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+            this.bytes = bytes;
+            this.variable = variable;
+        }
+
+        public long getBytes() {
+            return bytes;
+        }
+
+        public boolean isVariable() {
+            return variable;
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.putAll(Map.of(
+                    "type", "bytes",
+                    "bytes", bytes,
+                    "variable", variable
+            ));
+            return typeDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "Bytes{" +
+                    "bytes=" + bytes +
+                    ", variable=" + variable +
+                    ", logicalType='" + logicalType + '\'' +
+                    ", docString='" + docString + '\'' +
+                    ", extraAttributes=" + extraAttributes +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Bytes bytes1 = (Bytes) o;
+            return bytes == bytes1.bytes && variable == bytes1.variable;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), bytes, variable);
+        }
+    }
+
+    public static class List_ extends Type {
+        private final Type valueType;
+        private final Integer length;
+        private final boolean variable;
+
+        public List_(Type valueType) {
+            this(valueType, null, true);
+        }
+
+        public List_(Type valueType, boolean variable) {
+            this(valueType, null, variable);
+        }
+
+        public List_(Type valueType, Integer length, boolean variable) {
+            this(valueType, length, variable, null, null, null);
+        }
+
+        public List_(Type valueType, Integer length, boolean variable, String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+            this.valueType = valueType;
+            this.length = length;
+            this.variable = variable;
+        }
+
+        public Type getValueType() {
+            return valueType;
+        }
+
+        public Integer getLength() {
+            return length;
+        }
+
+        public boolean isVariable() {
+            return variable;
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.putAll(Map.of(
+                    "type", "list",
+                    "variable", variable,
+                    "values", valueType.toTypeDescription()
+            ));
+            if (length != null) {
+                typeDescription.put("length", length);
+            }
+            return typeDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "List_{" +
+                    "valueType=" + valueType +
+                    ", length=" + length +
+                    ", variable=" + variable +
+                    ", logicalType='" + logicalType + '\'' +
+                    ", docString='" + docString + '\'' +
+                    ", extraAttributes=" + extraAttributes +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            List_ list = (List_) o;
+            return length == list.length && variable == list.variable && Objects.equals(valueType, list.valueType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), valueType, length, variable);
+        }
+    }
+
+    public static class Map_ extends Type {
+        private final Type keyType;
+        private final Type valueType;
+
+        public Map_(Type keyType, Type valueType) {
+            this(keyType, valueType, null, null, null);
+        }
+
+        public Map_(Type keyType, Type valueType, String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+            this.keyType = keyType;
+            this.valueType = valueType;
+        }
+
+        public Type getKeyType() {
+            return keyType;
+        }
+
+        public Type getValueType() {
+            return valueType;
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.putAll(Map.of(
+                    "type", "map",
+                    "keys", keyType.toTypeDescription(),
+                    "values", valueType.toTypeDescription()
+            ));
+            return typeDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "Map_{" +
+                    "keyType=" + keyType +
+                    ", valueType=" + valueType +
+                    ", logicalType='" + logicalType + '\'' +
+                    ", docString='" + docString + '\'' +
+                    ", extraAttributes=" + extraAttributes +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Map_ map = (Map_) o;
+            return Objects.equals(keyType, map.keyType) && Objects.equals(valueType, map.valueType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), keyType, valueType);
+        }
+    }
+
+    public static class Struct extends Type {
+        List<? extends Type> fieldTypes;
+
+        public Struct(List<? extends Type> fieldTypes) {
+            this(fieldTypes, null, null, null);
+        }
+
+        public Struct(List<? extends Type> fieldTypes, String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+            this.fieldTypes = fieldTypes;
+        }
+
+        public List<? extends Type> getFieldTypes() {
+            return fieldTypes;
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.putAll(Map.of(
+                    "type", "struct",
+                    "fields", fieldTypes
+                            .stream()
+                            .map(Type::toTypeDescription)
+                            .collect(Collectors.toList())
+            ));
+            return typeDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "Struct{" +
+                    "fieldTypes=" + fieldTypes +
+                    ", logicalType='" + logicalType + '\'' +
+                    ", docString='" + docString + '\'' +
+                    ", extraAttributes=" + extraAttributes +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Struct struct = (Struct) o;
+            return Objects.equals(fieldTypes, struct.fieldTypes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), fieldTypes);
+        }
+    }
+
+    public static class Enum extends Type {
+        private final List<String> symbols;
+
+        public Enum(List<String> symbols) {
+            this(symbols, null, null, null);
+        }
+
+        public Enum(List<String> symbols, String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+            this.symbols = symbols;
+        }
+
+        public List<String> getSymbols() {
+            return symbols;
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.putAll(Map.of(
+                    "type", "enum",
+                    "symbols", symbols
+            ));
+            return typeDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "Enum{" +
+                    "symbols=" + symbols +
+                    ", logicalType='" + logicalType + '\'' +
+                    ", docString='" + docString + '\'' +
+                    ", extraAttributes=" + extraAttributes +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Enum anEnum = (Enum) o;
+            return Objects.equals(symbols, anEnum.symbols);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), symbols);
+        }
+    }
+
+    public static class Union extends Type {
+        private final List<? extends Type> types;
+
+        public Union(List<? extends Type> types) {
+            this(types, null, null, null);
+        }
+
+        public Union(List<? extends Type> types, String logicalType, String docString, Map<String, Object> extraAttributes) {
+            super(logicalType, docString, extraAttributes);
+            this.types = types;
+        }
+
+        public List<? extends Type> getTypes() {
+            return types;
+        }
+
+        public Map<String, Object> toTypeDescription() {
+            Map<String, Object> typeDescription = super.toTypeDescription();
+            typeDescription.putAll(Map.of(
+                    "type", "union",
+                    "types", types
+                            .stream()
+                            .map(Type::toTypeDescription)
+                            .collect(Collectors.toList())
+            ));
+            return typeDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "Union{" +
+                    "types=" + types +
+                    ", logicalType='" + logicalType + '\'' +
+                    ", docString='" + docString + '\'' +
+                    ", extraAttributes=" + extraAttributes +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Union union = (Union) o;
+            return Objects.equals(types, union.types);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), types);
+        }
+    }
+}

--- a/java/recap-core/src/test/java/build/recap/ClientTest.java
+++ b/java/recap-core/src/test/java/build/recap/ClientTest.java
@@ -1,0 +1,65 @@
+package build.recap;
+
+import junit.framework.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpResponse;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+public class ClientTest extends TestCase {
+
+    private HttpServer server;
+    private String serverUrl;
+    private TestHttpHandler handler;
+
+    protected void setUp() throws IOException {
+        handler = new TestHttpHandler();
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/test", handler);
+        server.start();
+        serverUrl = "http://localhost:" + server.getAddress().getPort() + "/test";
+    }
+
+    protected void tearDown() {
+        server.stop(0);
+    }
+
+    public void testPost() throws Exception {
+        Client client = new Client();
+        Type type = new Type.Bool();
+        HttpResponse<String> response = client.post(serverUrl, type);
+
+        assertNotNull(response);
+        assertEquals(200, response.statusCode());
+        assertEquals("application/json", handler.getReceivedContentType());
+        assertEquals("{\"type\":\"bool\"}", handler.getReceivedBody());
+    }
+
+    private static class TestHttpHandler implements HttpHandler {
+        private String receivedContentType;
+        private String receivedBody;
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            receivedContentType = exchange.getRequestHeaders().getFirst("Content-Type");
+            receivedBody = new String(exchange.getRequestBody().readAllBytes());
+            exchange.sendResponseHeaders(200, 0);
+            try (OutputStream responseBody = exchange.getResponseBody()) {
+                responseBody.write(new byte[0]);
+            }
+        }
+
+        public String getReceivedContentType() {
+            return receivedContentType;
+        }
+
+        public String getReceivedBody() {
+            return receivedBody;
+        }
+    }
+}

--- a/java/recap-core/src/test/java/build/recap/TypeTest.java
+++ b/java/recap-core/src/test/java/build/recap/TypeTest.java
@@ -1,0 +1,84 @@
+package build.recap;
+
+import junit.framework.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class TypeTest extends TestCase {
+    public void testTypeDescriptions() {
+        Type.Bool bool = new Type.Bool(null, null, Map.of("name", "bool"));
+        Type.Null null_ = new Type.Null(null, null, Map.of("name", "null"));
+        List<Type> fields = new ArrayList<>();
+        fields.add(bool);
+        fields.add(null_);
+        fields.add(new Type.Int(32, true, "build.recap.Time", "A logical type test", Map.of("name", "int32")));
+        fields.add(new Type.Float(64, null, null, Map.of("name", "double", "default", 32f)));
+        fields.add(new Type.String_(Integer.MAX_VALUE, true, null, null, Map.of("name", "string32")));
+        fields.add(new Type.Bytes(Integer.MAX_VALUE, false, null, null, Map.of("name", "bytes32")));
+        fields.add(new Type.List_(bool, Integer.MAX_VALUE, true, null, null, Map.of("name", "list32")));
+        fields.add(new Type.Map_(bool, bool, null, null, Map.of("name", "map")));
+        fields.add(new Type.Enum(List.of("red", "green", "blue"), null, null, Map.of("name", "enum")));
+        fields.add(new Type.Union(List.of(null_, bool), null, null, Map.of("name", "union")));
+        Type.Struct struct = new Type.Struct(fields);
+        Map<String, Object> description = struct.toTypeDescription();
+        assertEquals("struct", description.get("type"));
+        assertTrue("Struct fields attribute should be a list", description.get("fields") instanceof List<?>);
+        List<? extends Map<String, Object>> fieldDescriptions = (List<? extends Map<String, Object>>) description.get("fields");
+        assertEquals(fields.size(), fieldDescriptions.size());
+        Map<String, Object> boolDescription = Map.of("name", "bool", "type", "bool");
+        Map<String, Object> nullDescription = Map.of("name", "null", "type", "null");
+        assertEquals(boolDescription, fieldDescriptions.get(0));
+        assertEquals(nullDescription, fieldDescriptions.get(1));
+        assertEquals(Map.of(
+                "name", "int32",
+                "type", "int",
+                "bits", 32,
+                "signed", true,
+                "logical", "build.recap.Time",
+                "doc", "A logical type test"
+        ), fieldDescriptions.get(2));
+        assertEquals(Map.of(
+                "name", "double",
+                "type", "float",
+                "bits", 64,
+                "default", 32f
+        ), fieldDescriptions.get(3));
+        assertEquals(Map.of(
+                "name", "string32",
+                "type", "string",
+                "bytes", (long) Integer.MAX_VALUE,
+                "variable", true
+        ), fieldDescriptions.get(4));
+        assertEquals(Map.of(
+                "name", "bytes32",
+                "type", "bytes",
+                "bytes", (long) Integer.MAX_VALUE,
+                "variable", false
+        ), fieldDescriptions.get(5));
+        assertEquals(Map.of(
+                "name", "list32",
+                "type", "list",
+                "length", Integer.MAX_VALUE,
+                "variable", true,
+                "values", boolDescription
+        ), fieldDescriptions.get(6));
+        assertEquals(Map.of(
+                "name", "map",
+                "type", "map",
+                "keys", boolDescription,
+                "values", boolDescription
+        ), fieldDescriptions.get(7));
+        assertEquals(Map.of(
+                "name", "enum",
+                "type", "enum",
+                "symbols", List.of("red", "green", "blue")
+        ), fieldDescriptions.get(8));
+        assertEquals(Map.of(
+                "name", "union",
+                "type", "union",
+                "types", List.of(nullDescription, boolDescription)
+        ), fieldDescriptions.get(9));
+    }
+}

--- a/java/recap-kafka/pom.xml
+++ b/java/recap-kafka/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>build.recap</groupId>
+        <artifactId>recap</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>recap-kafka</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>build.recap</groupId>
+            <artifactId>recap-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/java/recap-kafka/src/main/java/build/recap/kafka/Converter.java
+++ b/java/recap-kafka/src/main/java/build/recap/kafka/Converter.java
@@ -1,0 +1,516 @@
+package build.recap.kafka;
+
+import build.recap.Data;
+import build.recap.Type;
+import build.recap.kafka.logical.DateConverter;
+import build.recap.kafka.logical.DecimalConverter;
+import build.recap.kafka.logical.LogicalConverter;
+import build.recap.kafka.logical.TimeConverter;
+import build.recap.kafka.logical.TimestampConverter;
+import org.apache.kafka.connect.data.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class Converter {
+    private final List<LogicalConverter> logicalConverters;
+
+    public Converter() {
+        this(List.of(
+                new DecimalConverter(),
+                new DateConverter(),
+                new TimeConverter(),
+                new TimestampConverter()
+        ));
+    }
+
+    public Converter(List<LogicalConverter> logicalConverters) {
+        this.logicalConverters = Collections.unmodifiableList(logicalConverters);
+    }
+
+    public Data convert(SchemaAndValue connectSchemaAndValue) {
+        Data convertedData = null;
+        SchemaAndValue connectSchemaAndValueLogical = convertLogical(connectSchemaAndValue);
+        Schema connectSchema = connectSchemaAndValue.schema();
+
+        switch (connectSchema.type()) {
+            case STRING:
+                convertedData = convertString(connectSchemaAndValueLogical);
+                break;
+            case INT8:
+            case INT16:
+            case INT32:
+            case INT64:
+                convertedData = convertInt(connectSchemaAndValueLogical);
+                break;
+            case FLOAT32:
+            case FLOAT64:
+                convertedData = convertFloat(connectSchemaAndValueLogical);
+                break;
+            case BOOLEAN:
+                convertedData = convertBool(connectSchemaAndValueLogical);
+                break;
+            case BYTES:
+                convertedData = convertBytes(connectSchemaAndValueLogical);
+                break;
+            case STRUCT:
+                convertedData = convertStruct((Struct) connectSchemaAndValueLogical.value());
+                break;
+            case ARRAY:
+                convertedData = convertList(connectSchemaAndValueLogical);
+                break;
+            case MAP:
+                convertedData = convertMap(connectSchemaAndValueLogical);
+                break;
+        }
+
+        if (convertedData != null) {
+            if (connectSchema.isOptional()) {
+                Type optionalType = new Type.Union(Arrays.asList(new Type.Null(), convertedData.getType()));
+                // KC does not differentiate between null default and unset default.
+                // Always set default even if it's null, since we don't know if it's explicitly so or not.
+                optionalType.getExtraAttributes().put("default", connectSchema.defaultValue());
+                convertedData = new Data(optionalType, convertedData.getObject());
+            }
+            return convertedData;
+        }
+
+        throw new RuntimeException("Unable to convert Kafka Connect data " + connectSchemaAndValue);
+    }
+
+    public SchemaAndValue convert(Data data) {
+        Data dataLogical = convertLogical(data);
+
+        if (dataLogical.getType() instanceof Type.String_) {
+            return convertString(dataLogical);
+        } else if (dataLogical.getType() instanceof Type.Int) {
+            return convertInt(dataLogical);
+        } else if (dataLogical.getType() instanceof Type.Float) {
+            return convertFloat(dataLogical);
+        } else if (dataLogical.getType() instanceof Type.Bytes) {
+            return convertBytes(dataLogical);
+        } else if (dataLogical.getType() instanceof Type.Bool) {
+            return convertBool(dataLogical);
+        } else if (dataLogical.getType() instanceof Type.Struct) {
+            return convertStruct(dataLogical);
+        } else if (dataLogical.getType() instanceof Type.List_) {
+            return convertList(dataLogical);
+        } else if (dataLogical.getType() instanceof Type.Map_) {
+            return convertMap(dataLogical);
+        } else if (dataLogical.getType() instanceof Type.Enum) {
+            return convertEnum(dataLogical);
+        } else if (dataLogical.getType() instanceof Type.Union) {
+            return convertUnion(dataLogical);
+        }
+        throw new UnsupportedOperationException("Unable to convert Recap data " + data);
+    }
+
+    protected Data convertString(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Object connectValue = connectSchemaAndValue.value();
+        Type.String_ recapStringType = new Type.String_(
+                Integer.MAX_VALUE,
+                true,
+                connectSchema.name(),
+                connectSchema.doc(),
+                (Map) connectSchema.parameters()
+        );
+        return new Data(recapStringType, connectValue);
+    }
+
+    protected SchemaAndValue convertString(Data data) {
+        Type.String_ recapStringType = (Type.String_) data.getType();
+        Schema connectSchema = setStandardAttributes(SchemaBuilder.string(), recapStringType).build();
+        if (recapStringType.getBytes() <= Integer.MAX_VALUE) {
+            return new SchemaAndValue(
+                    connectSchema,
+                    data.getObject()
+            );
+        }
+        throw new RuntimeException("Unable to convert Recap string " + data);
+    }
+
+    protected Data convertInt(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Object connectValue = connectSchemaAndValue.value();
+        Integer bits = null;
+        switch (connectSchema.type()) {
+            case INT8:
+                bits = 8;
+                break;
+            case INT16:
+                bits = 16;
+                break;
+            case INT32:
+                bits = 32;
+                break;
+            case INT64:
+                bits = 64;
+                break;
+        }
+        if (bits != null) {
+            Type.Int recapIntType = new Type.Int(
+                    bits,
+                    true,
+                    connectSchema.name(),
+                    connectSchema.doc(),
+                    (Map) connectSchema.parameters()
+            );
+            return new Data(recapIntType, connectValue);
+        }
+        throw new RuntimeException("Unable to convert Kafka Connect integer " + connectSchemaAndValue);
+    }
+
+    protected SchemaAndValue convertInt(Data data) {
+        Type.Int recapIntType = (Type.Int) data.getType();
+        if (recapIntType.getBits() <= 8) {
+            if (recapIntType.isSigned()) {
+                return new SchemaAndValue(
+                        setStandardAttributes(SchemaBuilder.int8(), recapIntType).build(),
+                        data.getObject());
+            } else {
+                return new SchemaAndValue(
+                        setStandardAttributes(SchemaBuilder.int16(), recapIntType).build(),
+                        data.getObject());
+            }
+        } else if (recapIntType.getBits() <= 16) {
+            if (recapIntType.isSigned()) {
+                return new SchemaAndValue(
+                        setStandardAttributes(SchemaBuilder.int16(), recapIntType).build(),
+                        data.getObject());
+            } else {
+                return new SchemaAndValue(
+                        setStandardAttributes(SchemaBuilder.int32(), recapIntType).build(),
+                        data.getObject());
+            }
+        } else if (recapIntType.getBits() <= 32) {
+            if (recapIntType.isSigned()) {
+                return new SchemaAndValue(
+                        setStandardAttributes(SchemaBuilder.int32(), recapIntType).build(),
+                        data.getObject());
+            } else {
+                return new SchemaAndValue(
+                        setStandardAttributes(SchemaBuilder.int64(), recapIntType).build(),
+                        data.getObject());
+            }
+        } else if (recapIntType.getBits() <= 64) {
+            if (recapIntType.isSigned()) {
+                return new SchemaAndValue(
+                        setStandardAttributes(SchemaBuilder.int64(), recapIntType).build(),
+                        data.getObject());
+            } else {
+                return new SchemaAndValue(
+                        setStandardAttributes(Decimal.builder(0), recapIntType).build(),
+                        data.getObject());
+            }
+        }
+        throw new RuntimeException("Unable to convert Recap integer " + data);
+    }
+
+    protected Data convertFloat(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Object connectValue = connectSchemaAndValue.value();
+        Integer bits = null;
+        switch (connectSchema.type()) {
+            case FLOAT32:
+                bits = 32;
+                break;
+            case FLOAT64:
+                bits = 64;
+                break;
+        }
+        if (bits != null) {
+            Type.Float recapFloatType = new Type.Float(
+                    bits,
+                    connectSchema.name(),
+                    connectSchema.doc(),
+                    (Map) connectSchema.parameters()
+            );
+            return new Data(recapFloatType, connectValue);
+        }
+        throw new RuntimeException("Unable to convert Kafka Connect float " + connectSchemaAndValue);
+    }
+
+    protected SchemaAndValue convertFloat(Data data) {
+        Type.Float recapFloatType = (Type.Float) data.getType();
+        if (recapFloatType.getBits() <= 32) {
+            return new SchemaAndValue(
+                    setStandardAttributes(SchemaBuilder.float32(), recapFloatType).build(),
+                    data.getObject());
+        } else if (recapFloatType.getBits() <= 64) {
+            return new SchemaAndValue(
+                    setStandardAttributes(SchemaBuilder.float64(), recapFloatType).build(),
+                    data.getObject());
+        }
+        throw new RuntimeException("Unable to convert Recap float " + data);
+    }
+
+    protected Data convertBytes(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Object connectValue = connectSchemaAndValue.value();
+        Type.Bytes recapBytesType = new Type.Bytes(
+                Integer.MAX_VALUE,
+                true,
+                connectSchema.name(),
+                connectSchema.doc(),
+                (Map) connectSchema.parameters()
+        );
+        return new Data(recapBytesType, connectValue);
+    }
+
+    protected SchemaAndValue convertBytes(Data data) {
+        Type.Bytes recapBytesType = (Type.Bytes) data.getType();
+        if (recapBytesType.getBytes() <= Integer.MAX_VALUE) {
+            return new SchemaAndValue(
+                    setStandardAttributes(SchemaBuilder.bytes(), recapBytesType).build(),
+                    data.getObject());
+        }
+        throw new RuntimeException("Unable to convert Recap bytes " + data);
+    }
+
+    protected Data convertBool(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Object connectValue = connectSchemaAndValue.value();
+        Type.Bool recapBoolType = new Type.Bool(
+                connectSchema.name(),
+                connectSchema.doc(),
+                (Map) connectSchema.parameters()
+        );
+        return new Data(recapBoolType, connectValue);
+    }
+
+    protected SchemaAndValue convertBool(Data data) {
+        return new SchemaAndValue(
+                setStandardAttributes(SchemaBuilder.bool(), data.getType()).build(),
+                data.getObject());
+    }
+
+    protected Data convertStruct(Struct connectStruct) {
+        // TODO: Need to handle null structs here.
+        Schema connectSchema = connectStruct.schema();
+        Type[] recapFieldTypes = new Type[connectSchema.fields().size()];
+        Map<Object, Object> recapStructFields = new LinkedHashMap<>();
+        for (Field connectField : connectSchema.fields()) {
+            Object connectFieldObject = connectStruct.get(connectField);
+            Data fieldData = convert(new SchemaAndValue(connectField.schema(), connectFieldObject));
+            recapFieldTypes[connectField.index()] = fieldData.getType();
+            recapFieldTypes[connectField.index()].getExtraAttributes().put("name", connectField.name());
+            recapStructFields.put(connectField.name(), fieldData.getObject());
+        }
+        Type.Struct recapStructType = new Type.Struct(
+                Arrays.asList(recapFieldTypes),
+                connectSchema.name(),
+                connectSchema.doc(),
+                (Map) connectSchema.parameters()
+        );
+        return new Data(recapStructType, recapStructFields);
+    }
+
+    protected SchemaAndValue convertStruct(Data data) {
+        Map<String, Object> connectStructFields = new LinkedHashMap<>();
+        Map<Object, Object> recapStructFields = (Map<Object, Object>) data.getObject();
+        Type.Struct recapStructType = (Type.Struct) data.getType();
+        SchemaBuilder connectSchemaBuilder = setStandardAttributes(SchemaBuilder.struct(), data.getType());
+        for (Type recapFieldType : recapStructType.getFieldTypes()) {
+            String fieldName = (String) recapFieldType.getExtraAttributes().get("name");
+            assert fieldName != null : "Can't convert unnamed field to Kafka Connect field";
+            // Allow null objects on non-null types like structs, so we can convert schemas for optional types.
+            Object recapFieldObject = recapStructFields != null ? recapStructFields.get(fieldName) : null;
+            Data fieldData = new Data(recapFieldType, recapFieldObject);
+            SchemaAndValue fieldSchemaAndValue = convert(fieldData);
+            connectStructFields.put(fieldName, fieldSchemaAndValue.value());
+            connectSchemaBuilder.field(fieldName, fieldSchemaAndValue.schema());
+        }
+        Struct connectStruct = new Struct(connectSchemaBuilder.build());
+        for (Map.Entry<String, Object> connectStructField : connectStructFields.entrySet()) {
+            connectStruct.put(connectStructField.getKey(), connectStructField.getValue());
+        }
+        return new SchemaAndValue(connectStruct.schema(), connectStruct);
+    }
+
+    protected Data convertList(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Schema connectValueSchema = connectSchema.valueSchema();
+        List<Object> connectList = connectSchemaAndValue.value() != null ? (List<Object>) connectSchemaAndValue.value() : Collections.emptyList();
+        List<Object> recapList = new ArrayList<>(connectList.size());
+        Type recapValueType = null;
+        for (Object valueObject : connectList) {
+            Data data = convert(new SchemaAndValue(connectValueSchema, valueObject));
+            recapValueType = data.getType();
+            recapList.add(data.getObject());
+        }
+        if (recapValueType == null) {
+            // Assume an empty list or null list, so send a null object to get schema.
+            recapValueType = convert(new SchemaAndValue(connectValueSchema, null)).getType();
+        }
+        Type.List_ recapListType = new Type.List_(
+                recapValueType,
+                null,
+                true,
+                connectSchema.name(),
+                connectSchema.doc(),
+                (Map) connectSchema.parameters()
+        );
+        return new Data(recapListType, recapList);
+    }
+
+    protected SchemaAndValue convertList(Data data) {
+        Type.List_ recapListType = (Type.List_) data.getType();
+        Type recapValueType = recapListType.getValueType();
+        List<Object> recapList = data.getObject() != null ? (List<Object>) data.getObject() : Collections.emptyList();
+        List<Object> connectList = new ArrayList<>(recapList.size());
+        Schema connectValueSchema = null;
+        // Kafka Connect has no concept of fixed-size or length-limited arrays.
+        // Put all Recap lists into KC's standard array.
+        for (Object valueObject : recapList) {
+            SchemaAndValue schemaAndValue = convert(new Data(recapValueType, valueObject));
+            connectValueSchema = schemaAndValue.schema();
+            connectList.add(schemaAndValue.value());
+        }
+        if (connectValueSchema == null) {
+            // Assume an empty list or null list, so send a null object to get schema.
+            connectValueSchema = convert(new Data(recapValueType, null)).schema();
+        }
+        Schema connectListSchema = setStandardAttributes(SchemaBuilder.array(connectValueSchema), data.getType()).build();
+        return new SchemaAndValue(connectListSchema, connectList);
+    }
+
+    protected Data convertMap(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Schema connectKeySchema = connectSchema.keySchema();
+        Schema connectValueSchema = connectSchema.valueSchema();
+        Map<Object, Object> connectMap = connectSchemaAndValue.value() != null ? (Map<Object, Object>) connectSchemaAndValue.value() : Collections.emptyMap();
+        Map<Object, Object> recapMap = new LinkedHashMap<>(connectMap.size());
+        Type recapKeyType = null;
+        Type recapValueType = null;
+        for (Map.Entry<Object, Object> mapEntry : connectMap.entrySet()) {
+            Data keyData = convert(new SchemaAndValue(connectKeySchema, mapEntry.getKey()));
+            Data valueData = convert(new SchemaAndValue(connectValueSchema, mapEntry.getValue()));
+            recapKeyType = keyData.getType();
+            recapValueType = valueData.getType();
+            recapMap.put(keyData.getObject(), valueData.getObject());
+        }
+        if (recapKeyType == null || recapValueType == null) {
+            assert recapValueType == recapKeyType : "Got null key type or value type, but not both. This is unexpected.";
+            // Assume an empty map or null map, so send a null object to get schemas.
+            recapKeyType = convert(new SchemaAndValue(connectKeySchema, null)).getType();
+            recapValueType = convert(new SchemaAndValue(connectValueSchema, null)).getType();
+        }
+        Type.Map_ recapMapType = new Type.Map_(
+                recapKeyType,
+                recapValueType,
+                connectSchema.name(),
+                connectSchema.doc(),
+                (Map) connectSchema.parameters()
+        );
+        return new Data(recapMapType, recapMap);
+    }
+
+    protected SchemaAndValue convertMap(Data data) {
+        Type.Map_ recapMapType = (Type.Map_) data.getType();
+        Type recapKeyType = recapMapType.getKeyType();
+        Type recapValueType = recapMapType.getValueType();
+        Map<Object, Object> recapMap = data.getObject() != null ? (Map<Object, Object>) data.getObject() : Collections.emptyMap();
+        Map<Object, Object> connectMap = new LinkedHashMap<>(recapMap.size());
+        Schema connectKeySchema = null;
+        Schema connectValueSchema = null;
+        for (Map.Entry<Object, Object> mapEntry : recapMap.entrySet()) {
+            SchemaAndValue keySchemaAndValue = convert(new Data(recapKeyType, mapEntry.getKey()));
+            SchemaAndValue valueSchemaAndValue = convert(new Data(recapValueType, mapEntry.getValue()));
+            connectKeySchema = keySchemaAndValue.schema();
+            connectValueSchema = valueSchemaAndValue.schema();
+            connectMap.put(keySchemaAndValue.value(), valueSchemaAndValue.value());
+        }
+        if (connectKeySchema == null || connectValueSchema == null) {
+            assert recapValueType == recapKeyType : "Got null key type or value type, but not both. This is unexpected.";
+            // Assume an empty map or null map, so send a null object to get schemas.
+            connectKeySchema = convert(new Data(recapKeyType, null)).schema();
+            connectValueSchema = convert(new Data(recapValueType, null)).schema();
+        }
+        Schema connectMapSchema = setStandardAttributes(SchemaBuilder.map(connectKeySchema, connectValueSchema), data.getType()).build();
+        return new SchemaAndValue(connectMapSchema, connectMap);
+    }
+
+    protected SchemaAndValue convertEnum(Data data) {
+        Schema connectSchema = setStandardAttributes(SchemaBuilder.string(), data.getType()).build();
+        return new SchemaAndValue(connectSchema, data.getObject());
+    }
+
+    protected SchemaAndValue convertUnion(Data data) {
+        Type.Union recapUnionType = (Type.Union) data.getType();
+        int recapNullTypeIndex = recapUnionType.getTypes().indexOf(new Type.Null());
+        if (recapNullTypeIndex >= 0 && recapUnionType.getTypes().size() == 2) {
+            Type recapNonNullType = recapUnionType.getTypes().get(1 - recapNullTypeIndex);
+            SchemaAndValue schemaAndValue = convert(new Data(recapNonNullType, data.getObject()));
+            SchemaBuilder schemaBuilder = null;
+            // TODO: Figure out a better way to clone a schema and make it optional.
+            if (schemaAndValue.schema().type().equals(Schema.Type.ARRAY)) {
+                schemaBuilder = SchemaBuilder.array(schemaAndValue.schema().valueSchema());
+            } else if (schemaAndValue.schema().type().equals(Schema.Type.MAP)) {
+                schemaBuilder = SchemaBuilder.map(
+                        schemaAndValue.schema().keySchema(),
+                        schemaAndValue.schema().valueSchema());
+            } else if (schemaAndValue.schema().type().equals(Schema.Type.STRUCT)) {
+                schemaBuilder = SchemaBuilder.struct();
+                for (Field structField : schemaAndValue.schema().fields()) {
+                    schemaBuilder.field(structField.name(), structField.schema());
+                }
+            } else {
+                schemaBuilder = SchemaBuilder.type(schemaAndValue.schema().type());
+            }
+            Schema optionalConnectSchema = setStandardAttributes(schemaBuilder, data.getType())
+                    .optional()
+                    .defaultValue(data.getType().getExtraAttributes().get("default"))
+                    .build();
+            return new SchemaAndValue(optionalConnectSchema, schemaAndValue.value());
+        }
+        throw new RuntimeException("Unable to convert Recap union " + data);
+    }
+
+    protected SchemaAndValue convertLogical(SchemaAndValue schemaAndValue) {
+        Schema connectSchema = schemaAndValue.schema();
+        if (connectSchema.name() != null) {
+            for (LogicalConverter logicalConverter : logicalConverters) {
+                if (logicalConverter.canConvertToRecap(connectSchema.name(), connectSchema.version())) {
+                    return logicalConverter.convert(schemaAndValue);
+                }
+            }
+        }
+        return schemaAndValue;
+    }
+
+    protected Data convertLogical(Data data) {
+        String recapLogicalType = data.getType().getLogicalType();
+        if (recapLogicalType != null) {
+            for (LogicalConverter logicalConverter : logicalConverters) {
+                if (logicalConverter.canConvertToConnect(recapLogicalType)) {
+                    return logicalConverter.convert(data);
+                }
+            }
+        }
+        return data;
+    }
+
+    public static SchemaBuilder setStandardAttributes(SchemaBuilder schemaBuilder, Type recapType) {
+        return schemaBuilder
+                .name(recapType.getLogicalType())
+                .doc(recapType.getDocString())
+                .parameters(convertExtraAttributes(recapType.getExtraAttributes()));
+    }
+
+    public static Map<String, String> convertExtraAttributes(Map<String, Object> recapExtraAttributes) {
+        if (recapExtraAttributes != null) {
+            return recapExtraAttributes
+                    .entrySet()
+                    .stream()
+                    // Remove reserved field attributes (name and default)
+                    .filter(e -> e.getValue() != null
+                            && !"name".equals(e.getKey())
+                            && !"default".equals(e.getKey()))
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> e.getValue().toString()));
+        }
+        return null;
+    }
+}

--- a/java/recap-kafka/src/main/java/build/recap/kafka/logical/DateConverter.java
+++ b/java/recap-kafka/src/main/java/build/recap/kafka/logical/DateConverter.java
@@ -1,0 +1,56 @@
+package build.recap.kafka.logical;
+
+import build.recap.Data;
+import build.recap.Type;
+import build.recap.kafka.Converter;
+import org.apache.kafka.connect.data.*;
+
+import java.util.Map;
+
+public class DateConverter implements LogicalConverter {
+    public static final String LOGICAL_TYPE = "build.recap.Date";
+    public static final String UNIT_ATTRIBUTE = "unit";
+
+    public boolean canConvertToConnect(String recapLogicalType) {
+        return LOGICAL_TYPE.equals(recapLogicalType);
+    }
+
+    public boolean canConvertToRecap(String connectSchemaName, Integer version) {
+        return Date.LOGICAL_NAME.equals(connectSchemaName) && Integer.valueOf(1).equals(version);
+    }
+
+    public SchemaAndValue convert(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Object connectValue = connectSchemaAndValue.value();
+        assert connectValue instanceof java.util.Date : "Expected date type to be Date, but wasn't.";
+        assert connectSchema.version() == 1 : "Expected date logical type version to be 1 but wasn't.";
+        SchemaBuilder schemaBuilder = Converter.setStandardAttributes(
+                        SchemaBuilder.int32(),
+                        new Type(
+                                LOGICAL_TYPE,
+                                connectSchema.doc(),
+                                (Map) connectSchema.parameters()
+                        ))
+                .parameter(UNIT_ATTRIBUTE, "millisecond");
+        if (connectSchema.isOptional()) {
+            schemaBuilder
+                    .optional()
+                    .defaultValue(connectSchema.defaultValue());
+        }
+        return new SchemaAndValue(schemaBuilder, connectValue);
+    }
+
+    public Data convert(Data data) {
+        Type.Int recapIntType = (Type.Int) data.getType();
+        Object date = data.getObject();
+        assert date instanceof java.util.Date : "Expected date type to be Date, but wasn't.";
+        Type.Int recapIntTypeWithKCLogical = new Type.Int(
+                32,
+                true,
+                Date.LOGICAL_NAME,
+                recapIntType.getDocString(),
+                recapIntType.getExtraAttributes()
+        );
+        return new Data(recapIntTypeWithKCLogical, date);
+    }
+}

--- a/java/recap-kafka/src/main/java/build/recap/kafka/logical/DecimalConverter.java
+++ b/java/recap-kafka/src/main/java/build/recap/kafka/logical/DecimalConverter.java
@@ -1,0 +1,61 @@
+package build.recap.kafka.logical;
+
+import build.recap.Data;
+import build.recap.Type;
+import build.recap.kafka.Converter;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class DecimalConverter implements LogicalConverter {
+    public static final String LOGICAL_TYPE = "build.recap.Decimal";
+    public static final String PRECISION_ATTRIBUTE = "precision";
+
+    public boolean canConvertToConnect(String recapLogicalType) {
+        return LOGICAL_TYPE.equals(recapLogicalType);
+    }
+
+    public boolean canConvertToRecap(String connectSchemaName, Integer version) {
+        return Decimal.LOGICAL_NAME.equals(connectSchemaName) && Integer.valueOf(1).equals(version);
+    }
+
+    public SchemaAndValue convert(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Object connectValue = connectSchemaAndValue.value();
+        assert connectValue instanceof BigDecimal : "Expected decimal type to be BigDecimal, but wasn't.";
+        assert connectSchema.version() == 1 : "Expected decimal logical type version to be 1 but wasn't.";
+        SchemaBuilder schemaBuilder = Converter.setStandardAttributes(
+                SchemaBuilder.bytes(),
+                new Type(
+                    LOGICAL_TYPE,
+                    connectSchema.doc(),
+                    (Map) connectSchema.parameters()
+            ))
+            // BigDecimals are capped to a 2 gig limit in Java
+            .parameter(PRECISION_ATTRIBUTE, Integer.toString(Integer.MAX_VALUE));
+        if (connectSchema.isOptional()) {
+            schemaBuilder
+                    .optional()
+                    .defaultValue(connectSchema.defaultValue());
+        }
+        return new SchemaAndValue(schemaBuilder, connectValue);
+    }
+
+    public Data convert(Data data) {
+        Type.Bytes recapBytesType = (Type.Bytes) data.getType();
+        Object decimal = data.getObject();
+        assert decimal instanceof BigDecimal : "Expected decimal type to be BigDecimal, but wasn't.";
+        Type.Bytes recapBytesTypeWithKCLogical = new Type.Bytes(
+                recapBytesType.getBytes(),
+                recapBytesType.isVariable(),
+                Decimal.LOGICAL_NAME,
+                recapBytesType.getDocString(),
+                recapBytesType.getExtraAttributes()
+        );
+        return new Data(recapBytesTypeWithKCLogical, decimal);
+    }
+}

--- a/java/recap-kafka/src/main/java/build/recap/kafka/logical/LogicalConverter.java
+++ b/java/recap-kafka/src/main/java/build/recap/kafka/logical/LogicalConverter.java
@@ -1,0 +1,11 @@
+package build.recap.kafka.logical;
+
+import build.recap.Data;
+import org.apache.kafka.connect.data.SchemaAndValue;
+
+public interface LogicalConverter {
+    boolean canConvertToConnect(String recapLogicalType);
+    boolean canConvertToRecap(String connectSchemaName, Integer version);
+    SchemaAndValue convert(SchemaAndValue connectSchemaAndValue);
+    Data convert(Data data);
+}

--- a/java/recap-kafka/src/main/java/build/recap/kafka/logical/TimeConverter.java
+++ b/java/recap-kafka/src/main/java/build/recap/kafka/logical/TimeConverter.java
@@ -1,0 +1,56 @@
+package build.recap.kafka.logical;
+
+import build.recap.Data;
+import build.recap.Type;
+import build.recap.kafka.Converter;
+import org.apache.kafka.connect.data.*;
+
+import java.util.Map;
+
+public class TimeConverter implements LogicalConverter {
+    public static final String LOGICAL_TYPE = "build.recap.Time";
+    public static final String UNIT_ATTRIBUTE = "unit";
+
+    public boolean canConvertToConnect(String recapLogicalType) {
+        return LOGICAL_TYPE.equals(recapLogicalType);
+    }
+
+    public boolean canConvertToRecap(String connectSchemaName, Integer version) {
+        return Time.LOGICAL_NAME.equals(connectSchemaName) && Integer.valueOf(1).equals(version);
+    }
+
+    public SchemaAndValue convert(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Object connectValue = connectSchemaAndValue.value();
+        assert connectValue instanceof java.util.Date : "Expected time type to be Date, but wasn't.";
+        assert connectSchema.version() == 1 : "Expected time logical type version to be 1 but wasn't.";
+        SchemaBuilder schemaBuilder = Converter.setStandardAttributes(
+                        SchemaBuilder.int32(),
+                        new Type(
+                                LOGICAL_TYPE,
+                                connectSchema.doc(),
+                                (Map) connectSchema.parameters()
+                        ))
+                .parameter(UNIT_ATTRIBUTE, "millisecond");
+        if (connectSchema.isOptional()) {
+            schemaBuilder
+                    .optional()
+                    .defaultValue(connectSchema.defaultValue());
+        }
+        return new SchemaAndValue(schemaBuilder, connectValue);
+    }
+
+    public Data convert(Data data) {
+        Type.Int recapIntType = (Type.Int) data.getType();
+        Object time = data.getObject();
+        assert time instanceof java.util.Date : "Expected time type to be Date, but wasn't.";
+        Type.Int recapIntTypeWithKCLogical = new Type.Int(
+                32,
+                true,
+                Time.LOGICAL_NAME,
+                recapIntType.getDocString(),
+                recapIntType.getExtraAttributes()
+        );
+        return new Data(recapIntTypeWithKCLogical, time);
+    }
+}

--- a/java/recap-kafka/src/main/java/build/recap/kafka/logical/TimestampConverter.java
+++ b/java/recap-kafka/src/main/java/build/recap/kafka/logical/TimestampConverter.java
@@ -1,0 +1,57 @@
+package build.recap.kafka.logical;
+
+import build.recap.Data;
+import build.recap.Type;
+import build.recap.kafka.Converter;
+import org.apache.kafka.connect.data.*;
+
+import java.util.Map;
+
+public class TimestampConverter implements LogicalConverter {
+    public static final String LOGICAL_TYPE = "build.recap.Timestamp";
+    public static final String UNIT_ATTRIBUTE = "unit";
+
+    public boolean canConvertToConnect(String recapLogicalType) {
+        return LOGICAL_TYPE.equals(recapLogicalType);
+    }
+
+    public boolean canConvertToRecap(String connectSchemaName, Integer version) {
+        return Timestamp.LOGICAL_NAME.equals(connectSchemaName) && Integer.valueOf(1).equals(version);
+    }
+
+    public SchemaAndValue convert(SchemaAndValue connectSchemaAndValue) {
+        Schema connectSchema = connectSchemaAndValue.schema();
+        Object connectValue = connectSchemaAndValue.value();
+        assert connectValue instanceof java.util.Date : "Expected timestamp type to be Date, but wasn't.";
+        assert connectSchema.version() == 1 : "Expected timestamp logical type version to be 1 but wasn't.";
+        SchemaBuilder schemaBuilder = Converter.setStandardAttributes(
+                        SchemaBuilder.int64(),
+                        new Type(
+                                LOGICAL_TYPE,
+                                connectSchema.doc(),
+                                (Map) connectSchema.parameters()
+                        ))
+                // "timezone" attribute isn't set because KC timestamps aren't zoned.
+                .parameter(UNIT_ATTRIBUTE, "millisecond");
+        if (connectSchema.isOptional()) {
+            schemaBuilder
+                    .optional()
+                    .defaultValue(connectSchema.defaultValue());
+        }
+        return new SchemaAndValue(schemaBuilder, connectValue);
+    }
+
+    public Data convert(Data data) {
+        Type.Int recapIntType = (Type.Int) data.getType();
+        Object timestamp = data.getObject();
+        assert timestamp instanceof java.util.Date : "Expected timestamp type to be Date, but wasn't.";
+        Type.Int recapIntTypeWithKCLogical = new Type.Int(
+                64,
+                true,
+                Timestamp.LOGICAL_NAME,
+                recapIntType.getDocString(),
+                recapIntType.getExtraAttributes()
+        );
+        return new Data(recapIntTypeWithKCLogical, timestamp);
+    }
+}

--- a/java/recap-kafka/src/test/java/build/recap/kafka/ConverterTest.java
+++ b/java/recap-kafka/src/test/java/build/recap/kafka/ConverterTest.java
@@ -1,0 +1,183 @@
+package build.recap.kafka;
+
+import build.recap.Data;
+import build.recap.Type;
+import junit.framework.*;
+import org.apache.kafka.connect.data.*;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+public class ConverterTest extends TestCase {
+    public void testConverter() {
+        Schema addressSchema = SchemaBuilder.struct().name("build.recap.kafka.Address")
+                .field("number", Schema.INT8_SCHEMA)
+                .build();
+        Schema personSchema = SchemaBuilder.struct().name("build.recap.kafka.Person")
+                .field("age", Schema.INT8_SCHEMA)
+                .field("address", addressSchema)
+                .build();
+        Struct addressStruct = new Struct(addressSchema)
+                .put("number", (byte) 100);
+        Struct personStruct = new Struct(personSchema)
+                .put("age", (byte) 75)
+                .put("address", addressStruct);
+
+        Converter connectConverter = new Converter();
+        Data convertedRecapData = connectConverter.convert(new SchemaAndValue(personStruct.schema(), personStruct));
+        SchemaAndValue convertedConnectData = connectConverter.convert(convertedRecapData);
+        assertEquals(personStruct, convertedConnectData.value());
+    }
+
+    public void testOptionalPrimitive() {
+        Schema addressSchema = SchemaBuilder.struct().name("build.recap.kafka.Address")
+                .field("number", Schema.OPTIONAL_INT8_SCHEMA)
+                .build();
+        Schema personSchema = SchemaBuilder.struct().name("build.recap.kafka.Person")
+                .field("age", Schema.INT8_SCHEMA)
+                .field("address", addressSchema)
+                .build();
+        Struct addressStruct = new Struct(addressSchema)
+                .put("number", (byte) 100);
+        Struct personStruct = new Struct(personSchema)
+                .put("age", (byte) 75)
+                .put("address", addressStruct);
+        Converter connectConverter = new Converter();
+        Data convertedRecapData = connectConverter.convert(new SchemaAndValue(personStruct.schema(), personStruct));
+        SchemaAndValue convertedConnectData = connectConverter.convert(convertedRecapData);
+        assertEquals(personStruct, convertedConnectData.value());
+    }
+
+    public void testPrimitives() {
+        Schema schema = SchemaBuilder.struct()
+                .field("int8", Schema.INT8_SCHEMA)
+                .field("int16", Schema.INT16_SCHEMA)
+                .field("int32", Schema.INT32_SCHEMA)
+                .field("int64", Schema.INT64_SCHEMA)
+                .field("float32", Schema.FLOAT32_SCHEMA)
+                .field("float64", Schema.FLOAT64_SCHEMA)
+                .field("string", Schema.STRING_SCHEMA)
+                .field("bytes", Schema.BYTES_SCHEMA)
+                .field("bool", Schema.BOOLEAN_SCHEMA)
+                .build();
+        Struct struct = new Struct(schema)
+                .put("int8", Byte.MAX_VALUE)
+                .put("int16", Short.MAX_VALUE)
+                .put("int32", Integer.MAX_VALUE)
+                .put("int64", Long.MAX_VALUE)
+                .put("float32", Float.MAX_VALUE)
+                .put("float64", Double.MAX_VALUE)
+                .put("string", "A string")
+                .put("bytes", new byte[] {0x1})
+                .put("bool", false);
+        Converter connectConverter = new Converter();
+        Data convertedRecapData = connectConverter.convert(new SchemaAndValue(struct.schema(), struct));
+        SchemaAndValue convertedConnectData = connectConverter.convert(convertedRecapData);
+        assertEquals(struct, convertedConnectData.value());
+    }
+
+    public void testOptionalPrimitives() {
+        Schema schema = SchemaBuilder.struct()
+                .field("int8", Schema.OPTIONAL_INT8_SCHEMA)
+                .field("int16", Schema.OPTIONAL_INT16_SCHEMA)
+                .field("int32", Schema.OPTIONAL_INT32_SCHEMA)
+                .field("int64", Schema.OPTIONAL_INT64_SCHEMA)
+                .field("float32", Schema.OPTIONAL_FLOAT32_SCHEMA)
+                .field("float64", Schema.OPTIONAL_FLOAT64_SCHEMA)
+                .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("bytes", Schema.OPTIONAL_BYTES_SCHEMA)
+                .field("bool", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+                .build();
+        // First test with unset values
+        Struct struct = new Struct(schema);
+        Converter connectConverter = new Converter();
+        Data convertedRecapData = connectConverter.convert(new SchemaAndValue(struct.schema(), struct));
+        SchemaAndValue convertedConnectData = connectConverter.convert(convertedRecapData);
+        assertEquals(struct, convertedConnectData.value());
+        // Now test with values set to null
+        struct
+                .put("int8", null)
+                .put("int16", null)
+                .put("int32", null)
+                .put("int64", null)
+                .put("float32", null)
+                .put("float64", null)
+                .put("string", null)
+                .put("bytes", null)
+                .put("bool", null);
+        convertedRecapData = connectConverter.convert(new SchemaAndValue(struct.schema(), struct));
+        convertedConnectData = connectConverter.convert(convertedRecapData);
+        assertEquals(struct, convertedConnectData.value());
+    }
+
+    public void testList() {
+        Schema nestedStructSchema = SchemaBuilder.struct().field("nested", Schema.INT32_SCHEMA).build();
+        Schema listSchema = SchemaBuilder.array(nestedStructSchema).build();
+        Schema structSchema = SchemaBuilder.struct().field("list", listSchema).build();
+        Struct nestedStruct = new Struct(nestedStructSchema).put("nested", 123);
+        Struct struct = new Struct(structSchema)
+                .put("list", Collections.singletonList(nestedStruct));
+        Converter connectConverter = new Converter();
+        Data convertedRecapData = connectConverter.convert(new SchemaAndValue(struct.schema(), struct));
+        SchemaAndValue convertedConnectData = connectConverter.convert(convertedRecapData);
+        assertEquals(struct, convertedConnectData.value());
+    }
+
+    public void testMap() {
+        Schema nestedStructSchema = SchemaBuilder.struct().field("nested", Schema.INT32_SCHEMA).build();
+        Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, nestedStructSchema).build();
+        Schema structSchema = SchemaBuilder.struct().field("map", mapSchema).build();
+        Struct nestedStruct = new Struct(nestedStructSchema).put("nested", 123);
+        Struct struct = new Struct(structSchema)
+                .put("map", Collections.singletonMap("test", nestedStruct));
+        Converter connectConverter = new Converter();
+        Data convertedRecapData = connectConverter.convert(new SchemaAndValue(struct.schema(), struct));
+        SchemaAndValue convertedConnectData = connectConverter.convert(convertedRecapData);
+        assertEquals(struct, convertedConnectData.value());
+    }
+
+    public void testEnum() {
+        Type.Enum recapEnumType = new Type.Enum(
+                Arrays.asList("red", "green", "blue"),
+                null,
+                null,
+                Collections.singletonMap("name", "enum"));
+        Type.Struct recapStructType = new Type.Struct(Collections.singletonList(recapEnumType));
+        Map<String, String> structMap = Collections.singletonMap("enum", "red");
+        Converter connectConverter = new Converter();
+        SchemaAndValue convertedConnectData = connectConverter.convert(new Data(recapStructType, structMap));
+        Schema structSchema = SchemaBuilder.struct().field("enum", Schema.STRING_SCHEMA).build();
+        Struct struct = new Struct(structSchema).put("enum", "red");
+        assertEquals(struct, convertedConnectData.value());
+    }
+
+    public void testLogicals() {
+        Schema schema = SchemaBuilder.struct()
+                .field("date", Date.SCHEMA)
+                .field("decimal", Decimal.schema(3))
+                .field("time", Time.SCHEMA)
+                .field("timestamp", Timestamp.SCHEMA)
+                .build();
+        Struct struct = new Struct(schema)
+                .put("date", new java.util.Date(1234567890))
+                .put("decimal", new BigDecimal("123.456"))
+                .put("time", new java.util.Date(12345L))
+                .put("timestamp", new java.util.Date(12345678901234L));
+        Converter connectConverter = new Converter();
+        Data convertedRecapData = connectConverter.convert(new SchemaAndValue(struct.schema(), struct));
+        SchemaAndValue convertedConnectData = connectConverter.convert(convertedRecapData);
+        // Can't do assertEquals(struct, convertedConnectData.value()); because convertedConnectData
+        // inherits the `precision` parameter from recap's decimal type, but that parameter isn't in the
+        // original struct schema.
+        for (Field field : schema.fields()) {
+            Type.Struct recapStructType = ((Type.Struct) convertedRecapData.getType());
+            Type recapFieldType = recapStructType.getFieldTypes().get(field.index());
+            assertTrue(recapFieldType.getLogicalType().startsWith("build.recap."));
+            assertEquals(field.schema().name(), convertedConnectData.schema().field(field.name()).schema().name());
+            assertEquals(field.schema().type(), convertedConnectData.schema().field(field.name()).schema().type());
+            assertEquals(struct.get(field), ((Struct) convertedConnectData.value()).get(field));
+        }
+    }
+}


### PR DESCRIPTION
The library provides a `recap-core` library which contains Recap's type system and a client for the Recap catalog.

The `recap-kafka` library provides a bridge to Kafka Connect's `SchemaAndValue` class. Integration with KC unlocks a ton of functionality for Recap since KC already has Proto, Avro, and JSON Schema converters.

The Java code is really MVP, but I wanted to bring it into the main project now.