### PR TITLE
Add logical support to Python types

### DIFF
--- a/python/recap/converters/recap.py
+++ b/python/recap/converters/recap.py
@@ -96,7 +96,6 @@ class RecapConverter(Converter):
         self.register_type(types.Bytes32)
         self.register_type(types.Bytes64)
         self.register_type(types.UUID)
-        self.register_type(types.Decimal)
         self.register_type(types.Decimal128)
         self.register_type(types.Decimal256)
         self.register_type(types.Duration64)
@@ -106,7 +105,6 @@ class RecapConverter(Converter):
         self.register_type(types.Timestamp64)
         self.register_type(types.Date32)
         self.register_type(types.Date64)
-        self.register_type(types.Decimal)
 
     def register_type(self, type_cls: type[types.Type]):
         """
@@ -258,6 +256,8 @@ class RecapConverter(Converter):
                 proxy_obj["alias"] = alias
             if doc := type_.doc:
                 proxy_obj["doc"] = doc
+            if logical := type_.logical:
+                proxy_obj["logical"] = logical
             if extra_attrs := type_.extra_attrs:
                 proxy_obj |= extra_attrs
             return proxy_obj

--- a/python/recap/types.py
+++ b/python/recap/types.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from enum import Enum as PyEnum
 from typing import Any, ClassVar
 
-FIELD_METADATA_NAMESPACE = "cloud.recap"
+FIELD_METADATA_NAMESPACE = "build.recap"
 FIELD_METADATA_TYPE = f"{FIELD_METADATA_NAMESPACE}.type"
 
 
@@ -13,6 +13,7 @@ class Type:
     default_alias: ClassVar[str]
     extra_attrs: dict[str, Any] = field(default_factory=dict)
     alias: str | None = None
+    logical: str | None = None
     doc: str | None = None
 
 
@@ -202,36 +203,34 @@ class UUID(String):
 
 
 @dataclass(kw_only=True)
-class Decimal(Bytes):
-    default_alias: ClassVar[str] = "decimal"
+class Decimal128(Bytes):
+    default_alias: ClassVar[str] = "decimal128"
     precision: int
     scale: int
-    bytes: int = 2_147_483_647
-
-
-@dataclass(kw_only=True)
-class Decimal128(Decimal):
-    default_alias: ClassVar[str] = "decimal128"
-
-
-@dataclass(kw_only=True)
-class Decimal256(Decimal):
-    default_alias: ClassVar[str] = "decimal256"
     bytes: int = 16
     variable: bool = False
 
 
+@dataclass(kw_only=True)
+class Decimal256(Bytes):
+    default_alias: ClassVar[str] = "decimal256"
+    precision: int
+    scale: int
+    bytes: int = 32
+    variable: bool = False
+
+
 class TimeUnit(str, PyEnum):
-    YEAR = "YEAR"
-    MONTH = "MONTH"
-    DAY = "DAY"
-    HOUR = "HOUR"
-    MINUTE = "MINUTE"
-    SECOND = "SECOND"
-    MILLISECOND = "MILLISECOND"
-    MICROSECOND = "MICROSECOND"
-    NANOSECOND = "NANOSECOND"
-    PICOSECOND = "PICOSECOND"
+    YEAR = "year"
+    MONTH = "month"
+    DAY = "day"
+    HOUR = "hour"
+    MINUTE = "minute"
+    SECOND = "second"
+    MILLISECOND = "millisecond"
+    MICROSECOND = "microsecond"
+    NANOSECOND = "nanosecond"
+    PICOSECOND = "picosecond"
 
 
 @dataclass(kw_only=True)

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -173,3 +173,12 @@ class TestTypes:
             ],
         )
         assert parsed == expected
+
+    def test_logical_to_recap(self):
+        obj = {
+            "type": "int32",
+            "logical": "time32",
+        }
+        parsed = RecapConverter().to_recap_type(obj)
+        expected = types.Int32(logical="time32")
+        assert parsed == expected


### PR DESCRIPTION
I added `logical` fields back to the spec while working on Recap's Java converters. I'm updating Python now to support the `logical` field so it's compatible with Recap Java and the spec.